### PR TITLE
fix: harden logs and router hot update checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 __pycache__/
 *.pyc
+.cache/
+.pytest_cache/
+.ruff_cache/
 .claude/
 .codex/
 .spec-workflow/

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -40,11 +40,21 @@ root/
 
 ## 提交前先这样验证
 
+建议本机准备这些开发工具：
+
+```sh
+python -m pip install pytest ruff paramiko
+```
+
+Lua / LuCI 相关改动还需要本机能找到 `lua` 和 `luac`。Windows 上可以用 Scoop 安装 Lua 5.1；Linux / WSL 上用发行版包管理器安装即可。
+
 先跑完整测试：
 
 ```sh
 python -m pytest tests/ -v
 ```
+
+`pytest.ini` 已把缓存目录改到 `.cache/pytest`，避免旧 `.pytest_cache` 权限异常反复污染测试输出。
 
 只想验证某一块时，可以直接跑：
 
@@ -53,6 +63,8 @@ python -m pytest tests/test_school_runtime_loader.py -v
 python -m pytest tests/ -k runtime -v
 ruff check root/usr/lib/smart_srun/
 ```
+
+测试里包含 OpenWrt / Lua 冒烟检查：`luac -p` 会解析 shipped LuCI Lua 文件，本机 `lua` 会用 stub LuCI 模块执行 `friendly_line()`。如果本机缺少 `luac` 或 `lua`，相关测试会失败，应该先安装工具而不是跳过。
 
 这个仓库很常见的一类改动，是只改了 Lua / JS / 打包脚本，没有很好地做路由器侧自动化。遇到这种情况，补一个 source-level 的 Python 回归测试是正常做法，比如直接断言某个 Lua 端点、按钮 ID、命令字符串或打包规则仍然存在。
 
@@ -69,7 +81,16 @@ python scripts/hot_update.py
 
 `SMARTSRUN_ROUTER_USER` 和 `SMARTSRUN_LUCI_BASE_URL` 是可选的。
 
-这个脚本会上传文件、跑远端语法检查、清 LuCI / Python 缓存、重启 `smart_srun` 和 `uwsgi`，然后再做 `srunnet status`、`srunnet schools`、`srunnet schools inspect --selected` 这些冒烟检查。
+生产热更新前，建议先跑两个低风险检查：
+
+```sh
+python scripts/hot_update.py --dry-run
+python scripts/hot_update.py --probe
+```
+
+`--dry-run` 只打印上传目标和远端命令，不连接路由器，也不需要密码。`--probe` 会把同一批文件上传到 `/tmp/smart_srun_probe_*`，在临时目录里跑 Python 编译 / import、logger、LuCI Lua、init 脚本和 CLI 版本冒烟检查，最后清理探针文件；它不会覆盖生产路径，也不会重启生产服务。
+
+不带参数的 `python scripts/hot_update.py` 是生产热更新：会上传文件到真实路径、跑远端语法检查、清 LuCI / Python 缓存、重启 `smart_srun` 和 `uwsgi`，然后再做 `srunnet status`、`srunnet schools`、`srunnet schools inspect --selected` 和 LuCI 页面验证。这个命令会覆盖路由器文件，只在已经明确确认要部署时执行。
 
 注意：`scripts/hot_update.py` 维护的是一份显式上传列表，不会自动扫描新文件。如果你新增了 shipped Python / Lua / JS 文件，记得把它加进去，不然本地改了、路由器上却没有。
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+cache_dir = .cache/pytest

--- a/root/usr/lib/lua/luci/controller/smart_srun.lua
+++ b/root/usr/lib/lua/luci/controller/smart_srun.lua
@@ -179,12 +179,13 @@ local function current_pending_runtime_action()
     return ""
 end
 
+local read_file_tail
+
 function action_status()
     local data = read_json_file(STATE_FILE)
-    local action = read_json_file(ACTION_FILE)
     local text = tostring(data.message or "未知")
     local pending = current_pending_runtime_action()
-    local last_log = util.trim(sys.exec("tail -n 1 " .. LOG_FILE .. " 2>/dev/null") or "")
+    local last_log = util.trim(read_file_tail(LOG_FILE, 1))
     local enabled = true
     if data.enabled == false or tostring(data.enabled or "") == "0" then
         enabled = false
@@ -639,6 +640,257 @@ local function extract_structured_suffix(rest, level, event)
     return util.trim(text:sub(#prefix + 1))
 end
 
+local function parse_quoted_log_value(text, idx)
+    local out = {}
+    idx = idx + 1
+    while idx <= #text do
+        local ch = text:sub(idx, idx)
+        if ch == "\\" and idx < #text then
+            local next_ch = text:sub(idx + 1, idx + 1)
+            if next_ch == '"' or next_ch == "\\" then
+                out[#out + 1] = next_ch
+            elseif next_ch == "n" or next_ch == "r" or next_ch == "t" then
+                out[#out + 1] = "\\" .. next_ch
+            else
+                out[#out + 1] = next_ch
+            end
+            idx = idx + 2
+        elseif ch == '"' then
+            return table.concat(out), idx + 1
+        else
+            out[#out + 1] = ch
+            idx = idx + 1
+        end
+    end
+    return table.concat(out), idx
+end
+
+local function parse_structured_fields(rest, level, event)
+    local text = extract_structured_suffix(rest, level, event)
+    local pipe_pos = text:find("%s|%s*")
+    if pipe_pos then
+        text = text:sub(1, pipe_pos - 1)
+    end
+
+    local fields = {}
+    local by_key = {}
+    local idx = 1
+    while idx <= #text do
+        while idx <= #text and text:sub(idx, idx):match("%s") do
+            idx = idx + 1
+        end
+        if idx > #text or text:sub(idx, idx) == "|" then
+            break
+        end
+
+        local remaining = text:sub(idx)
+        local key = remaining:match("^([%w_]+)=")
+        if not key then
+            local next_space = text:find("%s+", idx)
+            if not next_space then
+                break
+            end
+            idx = next_space + 1
+        else
+            idx = idx + #key + 1
+            local value = ""
+            if text:sub(idx, idx) == '"' then
+                value, idx = parse_quoted_log_value(text, idx)
+            else
+                value = text:match("^(%S+)", idx) or ""
+                idx = idx + #value
+            end
+            fields[#fields + 1] = { key = key, value = value }
+            if by_key[key] == nil then
+                by_key[key] = value
+            end
+        end
+    end
+    return fields, by_key
+end
+
+local friendly_field_order = {
+    "action",
+    "result",
+    "ok",
+    "duration_ms",
+    "queue_lag_ms",
+    "username",
+    "expected_username",
+    "username_reported",
+    "ip",
+    "resolved_ip",
+    "bind_ip",
+    "host",
+    "url",
+    "method",
+    "status_code",
+    "outcome",
+    "bytes_received",
+    "errors",
+    "error",
+    "error_code",
+    "attempts",
+    "delay",
+    "failures",
+    "target",
+    "ssid",
+    "radio",
+    "band",
+    "portal",
+    "section",
+    "network",
+    "iface",
+    "source",
+    "runtime_type",
+    "hook",
+    "school",
+    "mode",
+    "pid",
+    "interval",
+    "log_level",
+}
+
+local friendly_field_labels = {
+    action = "动作",
+    result = "结果",
+    ok = "成功",
+    duration_ms = "耗时",
+    queue_lag_ms = "排队",
+    username = "账号",
+    expected_username = "期望账号",
+    username_reported = "在线账号",
+    ip = "IP",
+    resolved_ip = "客户端IP",
+    bind_ip = "绑定IP",
+    host = "主机",
+    url = "URL",
+    method = "方法",
+    status_code = "状态码",
+    outcome = "结果",
+    bytes_received = "字节",
+    errors = "错误数",
+    error = "错误",
+    error_code = "错误码",
+    attempts = "次数",
+    delay = "延迟",
+    failures = "失败数",
+    target = "目标",
+    ssid = "SSID",
+    radio = "频段",
+    band = "频段",
+    portal = "认证页",
+    section = "配置段",
+    network = "网络",
+    iface = "接口",
+    source = "来源",
+    runtime_type = "运行时",
+    hook = "钩子",
+    school = "学校",
+    mode = "模式",
+    pid = "PID",
+    interval = "间隔",
+    log_level = "日志等级",
+}
+
+local hidden_friendly_fields = {
+    op_id = true,
+    cycle_id = true,
+}
+
+local sensitive_friendly_key_parts = {
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "chksum",
+    "checksum",
+    "hmd5",
+    "credential",
+    "authorization",
+    "cookie",
+    "session",
+    "private_key",
+    "campus_key",
+    "hotspot_key",
+    "wifi_key",
+    "psk",
+}
+
+local function is_hidden_friendly_field(key)
+    local name = tostring(key or ""):lower()
+    if hidden_friendly_fields[name] then
+        return true
+    end
+    for _, part in ipairs(sensitive_friendly_key_parts) do
+        if name:find(part, 1, true) then
+            return true
+        end
+    end
+    return false
+end
+
+local function friendly_field_value(key, value)
+    local text = tostring(value or "")
+    if key == "reason" or key == "error_code" then
+        text = reason_zh[text] or text
+    elseif text == "True" or text == "true" then
+        text = "是"
+    elseif text == "False" or text == "false" then
+        text = "否"
+    end
+
+    if key == "duration_ms" or key == "queue_lag_ms" then
+        text = text .. "ms"
+    end
+    return text
+end
+
+local function append_friendly_fields(parts, field_list, field_map, skipped)
+    local rendered = {}
+    local used = {}
+    skipped = skipped or {}
+
+    local function add_field(key, value)
+        if used[key] or skipped[key] or is_hidden_friendly_field(key) then
+            return
+        end
+        if value == nil or tostring(value) == "" then
+            return
+        end
+        used[key] = true
+        rendered[#rendered + 1] = (friendly_field_labels[key] or key) .. "=" .. friendly_field_value(key, value)
+    end
+
+    for _, key in ipairs(friendly_field_order) do
+        add_field(key, field_map[key])
+    end
+    for _, item in ipairs(field_list) do
+        add_field(item.key, item.value)
+    end
+
+    if #rendered > 0 then
+        parts[#parts + 1] = "（" .. table.concat(rendered, "，") .. "）"
+    end
+end
+
+local function append_message_detail(parts, rest, has_prior_detail)
+    local detail = rest:match("|%s*(.+)$")
+    if detail and detail ~= "" then
+        parts[#parts + 1] = (has_prior_detail and " · " or ": ") .. detail
+        return true
+    end
+    return has_prior_detail
+end
+
+local function skip_fields(...)
+    local skipped = {}
+    for i = 1, select("#", ...) do
+        skipped[tostring(select(i, ...))] = true
+    end
+    return skipped
+end
+
 local switch_stage_zh = {
     applying = "应用无线配置",
     wait_ip  = "等待获取 IPv4",
@@ -673,37 +925,43 @@ function friendly_line(line)
         return table.concat(parts)
     end
 
+    local field_list, field_map = parse_structured_fields(rest, level, event)
+
     if event == "switch_progress" then
-        local stage = extract_kv(rest, "stage")
+        local stage = field_map.stage or extract_kv(rest, "stage")
         local stage_zh = stage and switch_stage_zh[stage]
         if stage_zh then parts[#parts + 1] = " · " .. stage_zh end
-        local target = extract_kv(rest, "target")
+        local target = field_map.target or extract_kv(rest, "target")
         if target then parts[#parts + 1] = "（" .. target .. "）" end
+        append_message_detail(parts, rest, false)
+        append_friendly_fields(parts, field_list, field_map, skip_fields("stage", "target"))
         return table.concat(parts)
     end
 
     if event == "action_started" then
-        local action = extract_kv(rest, "action")
+        local action = field_map.action or extract_kv(rest, "action")
         if action then parts[#parts + 1] = "：" .. action end
+        append_message_detail(parts, rest, false)
+        append_friendly_fields(parts, field_list, field_map, skip_fields("action"))
         return table.concat(parts)
     end
 
-    local account = extract_kv(rest, "account")
+    local account = field_map.account or extract_kv(rest, "account")
     if account then parts[#parts + 1] = " [" .. account .. "]" end
 
-    local reason = extract_kv(rest, "reason")
+    local reason = field_map.reason or extract_kv(rest, "reason")
+    local has_detail = false
     if reason then
         local rzh = reason_zh[reason]
         parts[#parts + 1] = ": " .. (rzh or reason)
+        has_detail = true
     end
 
-    local attempt = rest:match("attempt=(%d+)")
+    local attempt = field_map.attempt or rest:match("attempt=(%d+)")
     if attempt then parts[#parts + 1] = " (第" .. attempt .. "次)" end
 
-    local detail = rest:match("|%s*(.+)$")
-    if detail and not reason and not account then
-        parts[#parts + 1] = ": " .. detail
-    end
+    append_message_detail(parts, rest, has_detail)
+    append_friendly_fields(parts, field_list, field_map, skip_fields("account", "reason", "attempt"))
 
     return table.concat(parts)
 end
@@ -735,8 +993,33 @@ local function structured_unix_ts(line)
     })
 end
 
+local function tail_text(text, lines)
+    lines = tonumber(lines) or 0
+    if lines <= 0 or text == "" then
+        return text
+    end
+
+    local entries = {}
+    for line in text:gmatch("[^\n]+") do
+        entries[#entries + 1] = line
+    end
+    if #entries <= lines then
+        return table.concat(entries, "\n")
+    end
+
+    local kept = {}
+    for idx = #entries - lines + 1, #entries do
+        kept[#kept + 1] = entries[idx]
+    end
+    return table.concat(kept, "\n")
+end
+
+read_file_tail = function(path, lines)
+    return tail_text(fs.readfile(path) or "", lines)
+end
+
 local function read_plugin_log_text(lines)
-    return sys.exec("tail -n " .. lines .. " " .. LOG_FILE .. " 2>/dev/null") or ""
+    return read_file_tail(LOG_FILE, lines)
 end
 
 local function read_plugin_full_log_text()
@@ -759,13 +1042,14 @@ local function filter_text_since(text, since)
 end
 
 local function read_system_log_text(lines)
+    lines = tonumber(lines) or LOG_TAIL_SOURCE_LINES
     local ok, text = pcall(sys.exec, "logread -l " .. lines .. " 2>/dev/null")
     if ok and text and text ~= "" then
         return text
     end
-    ok, text = pcall(sys.exec, "logread 2>/dev/null | tail -n " .. lines)
+    ok, text = pcall(sys.exec, "logread 2>/dev/null")
     if ok and text then
-        return text
+        return tail_text(text, lines)
     end
     return ""
 end

--- a/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
+++ b/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
@@ -7,6 +7,7 @@ local schema = require "luci.smart_srun.schema"
 
 local CONFIG_FILE = "/usr/lib/smart_srun/config.json"
 local STATE_FILE = "/var/run/smart_srun/state.json"
+local LOG_FILE = "/var/log/smart_srun.log"
 local JS_ASSET_PATH = "/luci-static/resources/smart_srun.js"
 local GLOBAL_SCALAR_KEYS = schema.GLOBAL_SCALAR_KEYS
 local POINTER_KEYS = schema.POINTER_KEYS
@@ -50,6 +51,28 @@ end
 
 local function render_js_asset_tag()
     return '<script src="' .. util.pcdata(JS_ASSET_PATH) .. '"></script>'
+end
+
+local function read_file_tail(path, lines)
+    lines = tonumber(lines) or 0
+    local text = fs.readfile(path) or ""
+    if lines <= 0 or text == "" then
+        return text
+    end
+
+    local entries = {}
+    for line in text:gmatch("[^\n]+") do
+        entries[#entries + 1] = line
+    end
+    if #entries <= lines then
+        return table.concat(entries, "\n")
+    end
+
+    local kept = {}
+    for idx = #entries - lines + 1, #entries do
+        kept[#kept + 1] = entries[idx]
+    end
+    return table.concat(kept, "\n")
 end
 
 local function is_legacy_config(parsed)
@@ -928,7 +951,7 @@ bind_text(log_level, "log_level")
 log_text = s:taboption("log", DummyValue, "_log_text", "运行日志")
 log_text.rawhtml = true
 function log_text.cfgvalue(self, section)
-    local t = sys.exec("tail -n 100 /var/log/smart_srun.log 2>/dev/null") or ""
+    local t = read_file_tail(LOG_FILE, 100)
     if t ~= "" then
         t = log_controller.friendly_log_text(t)
     end

--- a/root/usr/lib/smart_srun/client.py
+++ b/root/usr/lib/smart_srun/client.py
@@ -24,7 +24,7 @@ _here = os.path.dirname(os.path.abspath(__file__))
 if _here not in sys.path:
     sys.path.insert(0, _here)
 
-from cli import main
+from cli import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/root/usr/lib/smart_srun/config.py
+++ b/root/usr/lib/smart_srun/config.py
@@ -9,23 +9,23 @@ import os
 import re
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
-from logger import (
-    BEIJING_TZ,
-    LOG_FILE,
-    LOG_MAX_BYTES,
-    LOG_LEVEL_NAMES,
-    DEFAULT_LOG_LEVEL,
-    append_log,
-    clear_log_context,
-    get_log_threshold,
-    log,
-    normalize_level as normalize_log_level,
-    set_log_context,
-    set_log_threshold,
-    timed,
-)
+import logger as _logger
+
+BEIJING_TZ = _logger.BEIJING_TZ
+LOG_FILE = _logger.LOG_FILE
+LOG_MAX_BYTES = _logger.LOG_MAX_BYTES
+LOG_LEVEL_NAMES = _logger.LOG_LEVEL_NAMES
+DEFAULT_LOG_LEVEL = _logger.DEFAULT_LOG_LEVEL
+append_log = _logger.append_log
+clear_log_context = _logger.clear_log_context
+get_log_threshold = _logger.get_log_threshold
+log = _logger.log
+normalize_log_level = _logger.normalize_level
+set_log_context = _logger.set_log_context
+set_log_threshold = _logger.set_log_threshold
+timed = _logger.timed
 
 JSON_CONFIG_FILE = "/usr/lib/smart_srun/config.json"
 STATE_FILE = "/var/run/smart_srun/state.json"
@@ -124,7 +124,7 @@ def _load_defaults():
                 else:
                     out[k] = str(v)
             return out
-    except Exception:
+    except (OSError, TypeError, ValueError):
         pass
     return {
         "enabled": "0",
@@ -217,7 +217,7 @@ def _load_json_file_unlocked(path, allowed_keys=None):
             if allowed_keys is None:
                 return data
             return {k: data[k] for k in data if k in allowed_keys}
-    except Exception:
+    except (OSError, TypeError, ValueError):
         pass
     return {}
 
@@ -257,7 +257,7 @@ def load_json_raw_config():
             data = json.load(rf)
         if isinstance(data, dict):
             return data
-    except Exception:
+    except (OSError, TypeError, ValueError):
         pass
     return {}
 
@@ -296,7 +296,7 @@ def update_json_raw_config(updater):
 # ---------------------------------------------------------------------------
 
 
-# log() / append_log() are imported from logger.py at module top.
+# logger helpers are re-exported for existing modules that import them from config.py.
 
 
 # ---------------------------------------------------------------------------
@@ -434,12 +434,12 @@ def validate_school_extra(raw_cfg, descriptors):
         if value_type == "int":
             try:
                 int(text)
-            except Exception:
+            except (TypeError, ValueError):
                 errors.append({"key": key, "message": "%s must be an integer." % label})
         elif value_type == "float":
             try:
                 float(text)
-            except Exception:
+            except (TypeError, ValueError):
                 errors.append({"key": key, "message": "%s must be a number." % label})
         elif value_type == "bool":
             if text.lower() not in (
@@ -475,7 +475,7 @@ def normalize_school_extra(raw_cfg, descriptors):
             continue
         try:
             value = _coerce_school_extra_value(payload.get(key), descriptor)
-        except Exception:
+        except (TypeError, ValueError):
             return {}
         if value != "":
             normalized[key] = value
@@ -539,7 +539,7 @@ def _get_school_metadata(cfg):
         if metadata:
             return metadata
         return schools.get_default_school_metadata()
-    except Exception:
+    except (AttributeError, ImportError, LookupError, ValueError):
         return {"short_name": school_key, "no_suffix_operators": ["xn"]}
 
 
@@ -670,7 +670,7 @@ def parse_non_negative_int(value, default_value):
     try:
         parsed = int(str(value).strip())
         return parsed if parsed >= 0 else int(default_value)
-    except Exception:
+    except (TypeError, ValueError):
         return int(default_value)
 
 
@@ -678,7 +678,7 @@ def parse_non_negative_float(value, default_value):
     try:
         parsed = float(str(value).strip())
         return parsed if parsed >= 0 else float(default_value)
-    except Exception:
+    except (TypeError, ValueError):
         return float(default_value)
 
 
@@ -781,9 +781,6 @@ def apply_default_selection_for_runtime(expect_hotspot, reason=""):
         lambda current: current.__setitem__(meta["active_key"], default_id)
     )
 
-    suffix = ""
-    if reason:
-        suffix = "（%s）" % str(reason).strip()
     log(
         "INFO",
         "config_default_applied",
@@ -971,7 +968,7 @@ def load_config():
         try:
             save_json_raw_config(raw)
             log("INFO", "config_migrated", "legacy config migrated to new format")
-        except Exception:
+        except OSError:
             pass
 
     cfg = {}
@@ -1177,7 +1174,7 @@ def get_manual_terminal_check_attempts(cfg):
     try:
         attempts = int(str(cfg.get("manual_terminal_check_max_attempts", "5")).strip())
         return attempts if attempts > 0 else 5
-    except Exception:
+    except (TypeError, ValueError):
         return 5
 
 

--- a/root/usr/lib/smart_srun/daemon.py
+++ b/root/usr/lib/smart_srun/daemon.py
@@ -10,7 +10,6 @@ import time
 from config import (
     ACTION_FILE,
     LOG_FILE,
-    append_log,
     build_school_runtime_luci_contract,
     log,
     campus_uses_wired,
@@ -438,7 +437,7 @@ def _acquire_daemon_lock():
 
 
 def run_daemon(runtime=None):
-    daemon_lock = _acquire_daemon_lock()
+    _daemon_lock = _acquire_daemon_lock()
     reconcile_manual_login_service_guard()
     state = _make_daemon_state()
     startup_cfg = load_config()

--- a/root/usr/lib/smart_srun/logger.py
+++ b/root/usr/lib/smart_srun/logger.py
@@ -36,6 +36,26 @@ _EMIT_WEIGHTS = {k: v for k, v in LOG_LEVEL_WEIGHTS.items() if k != "ALL"}
 _threshold = LOG_LEVEL_WEIGHTS[DEFAULT_LOG_LEVEL]
 _context = {}
 
+_REDACTED_VALUE = "***"
+_SENSITIVE_KEY_PARTS = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "chksum",
+    "checksum",
+    "hmd5",
+    "credential",
+    "authorization",
+    "cookie",
+    "session",
+    "private_key",
+    "campus_key",
+    "hotspot_key",
+    "wifi_key",
+    "psk",
+)
+
 
 def normalize_level(level):
     name = str(level or "").strip().upper()
@@ -98,8 +118,20 @@ class timed(object):
         return False
 
 
-def _format_value(value):
+def _format_text(value):
     sv = str(value)
+    sv = sv.replace("\\", "\\\\")
+    sv = sv.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+    return sv
+
+
+def _is_sensitive_key(key):
+    name = str(key or "").strip().lower()
+    return any(part in name for part in _SENSITIVE_KEY_PARTS)
+
+
+def _format_value(value, key=None):
+    sv = _REDACTED_VALUE if _is_sensitive_key(key) else _format_text(value)
     if " " in sv or not sv or '"' in sv:
         sv = '"%s"' % sv.replace('"', '\\"')
     return sv
@@ -122,12 +154,12 @@ def log(level, event, msg="", **ctx):
         for k, v in _context.items():
             if k in ctx:
                 continue
-            parts.append("%s=%s" % (k, _format_value(v)))
+            parts.append("%s=%s" % (k, _format_value(v, k)))
     for k, v in ctx.items():
-        parts.append("%s=%s" % (k, _format_value(v)))
+        parts.append("%s=%s" % (k, _format_value(v, k)))
 
     if msg:
-        parts.append("| %s" % msg)
+        parts.append("| %s" % _format_text(msg))
 
     _write_log("[%s] %s" % (timestamp, " ".join(parts)))
 
@@ -138,7 +170,7 @@ def append_log(line):
         "[%s] %s"
         % (
             datetime.now(BEIJING_TZ).strftime("%Y-%m-%d %H:%M:%S"),
-            str(line).strip(),
+            _format_text(str(line).strip()),
         )
     )
 
@@ -148,13 +180,23 @@ def _write_log(log_line):
     print(log_line, flush=True)
     try:
         if os.path.exists(LOG_FILE) and os.path.getsize(LOG_FILE) > LOG_MAX_BYTES:
-            with open(LOG_FILE, "r", encoding="utf-8", errors="replace") as rf:
-                content = rf.read()
-            keep = content[-(LOG_MAX_BYTES // 2):]
-            with open(LOG_FILE, "w", encoding="utf-8") as wf:
-                wf.write(keep)
+            _rotate_log_tail()
 
         with open(LOG_FILE, "a", encoding="utf-8") as af:
             af.write(log_line + "\n")
     except OSError:
         pass
+
+
+def _rotate_log_tail():
+    keep_bytes = LOG_MAX_BYTES // 2
+    with open(LOG_FILE, "rb") as rf:
+        rf.seek(0, os.SEEK_END)
+        size = rf.tell()
+        rf.seek(max(0, size - keep_bytes), os.SEEK_SET)
+        if size > keep_bytes:
+            rf.readline()
+        keep = rf.read()
+
+    with open(LOG_FILE, "wb") as wf:
+        wf.write(keep)

--- a/root/usr/lib/smart_srun/network.py
+++ b/root/usr/lib/smart_srun/network.py
@@ -178,31 +178,32 @@ def get_local_ip_for_target(target_host):
         return None
 
 
+def _parse_network_interface_status(text):
+    try:
+        data = json.loads(text)
+    except (TypeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def get_ipv4_from_network_interface(iface_name):
     if not iface_name:
         return None
 
     ok, out = run_cmd(["ubus", "call", "network.interface.%s" % iface_name, "status"])
+    data = _parse_network_interface_status(out) if ok and out else {}
     if ok and out:
-        try:
-            data = json.loads(out)
-            ipv4_list = data.get("ipv4-address") or data.get("ipv4_address") or []
-            if isinstance(ipv4_list, list):
-                for item in ipv4_list:
-                    if isinstance(item, dict):
-                        addr = pick_valid_ip(item.get("address"))
-                        if addr:
-                            return addr
-        except Exception:
-            pass
+        ipv4_list = data.get("ipv4-address") or data.get("ipv4_address") or []
+        if isinstance(ipv4_list, list):
+            for item in ipv4_list:
+                if isinstance(item, dict):
+                    addr = pick_valid_ip(item.get("address"))
+                    if addr:
+                        return addr
 
     dev = iface_name
-    if ok and out:
-        try:
-            data = json.loads(out)
-            dev = data.get("l3_device") or data.get("device") or dev
-        except Exception:
-            pass
+    if data:
+        dev = data.get("l3_device") or data.get("device") or dev
 
     ok2, out2 = run_cmd(["ip", "-4", "-o", "addr", "show", "dev", dev])
     if ok2 and out2:

--- a/root/usr/lib/smart_srun/orchestrator.py
+++ b/root/usr/lib/smart_srun/orchestrator.py
@@ -9,7 +9,6 @@ import time
 
 from config import (
     ACTION_FILE,
-    append_log,
     log,
     apply_default_selection_for_runtime,
     backoff_enabled,
@@ -26,15 +25,12 @@ from config import (
     load_config,
     load_json_file,
     localize_error,
-    quiet_window_label,
     restore_manual_login_service_guard,
     set_log_context,
     timed,
 )
 from network import (
-    HTTP_EXCEPTIONS,
     resolve_bind_ip,
-    test_internet_connectivity,
 )
 from wireless import (
     detect_runtime_mode,

--- a/root/usr/lib/smart_srun/schools/_base.py
+++ b/root/usr/lib/smart_srun/schools/_base.py
@@ -14,7 +14,7 @@ _parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _parent_dir not in sys.path:
     sys.path.insert(0, _parent_dir)
 
-import crypto
+import crypto  # noqa: E402
 
 
 class SchoolProfile:

--- a/root/usr/lib/smart_srun/snapshot.py
+++ b/root/usr/lib/smart_srun/snapshot.py
@@ -22,7 +22,7 @@ from wireless import (
     get_sta_profile_from_section,
     parse_wireless_iface_data,
 )
-import srun_auth
+import srun_auth  # noqa: F401
 from school_runtime import build_app_context
 
 

--- a/root/usr/lib/smart_srun/srun_auth.py
+++ b/root/usr/lib/smart_srun/srun_auth.py
@@ -7,7 +7,7 @@ SRun 认证 API -- challenge、login、logout、在线查询。
 
 import time
 
-from config import append_log, localize_error, log, timed
+from config import localize_error, log, timed
 from network import (
     HTTP_EXCEPTIONS,
     extract_ip_from_text,

--- a/root/usr/lib/smart_srun/wireless.py
+++ b/root/usr/lib/smart_srun/wireless.py
@@ -9,7 +9,6 @@ import re
 import time
 
 from config import (
-    append_log,
     log,
     timed,
     campus_uses_wired,
@@ -26,8 +25,6 @@ from config import (
 )
 from network import (
     get_ipv4_from_network_interface,
-    get_local_ip_for_target,
-    http_get,
     parse_uci_value,
     run_cmd,
     test_internet_connectivity,

--- a/root/www/luci-static/resources/smart_srun.js
+++ b/root/www/luci-static/resources/smart_srun.js
@@ -88,6 +88,18 @@
     xhr.send(null);
   }
 
+  function isPageHidden() {
+    return document.hidden === true || document.webkitHidden === true;
+  }
+
+  function onPageVisible(callback) {
+    function runIfVisible() {
+      if (!isPageHidden()) callback();
+    }
+    document.addEventListener('visibilitychange', runIfVisible, false);
+    document.addEventListener('webkitvisibilitychange', runIfVisible, false);
+  }
+
   function normalizeVersionText(value) {
     var text = String(value == null ? '' : value).trim();
     var match = text.match(/^v?([^-]+)-r?(\d+)$/);
@@ -596,7 +608,10 @@
     }
 
     refreshOverview();
-    window.setInterval(refreshOverview, 1200);
+    window.setInterval(function() {
+      if (!isPageHidden()) refreshOverview();
+    }, 1200);
+    onPageVisible(refreshOverview);
   }
 
   function initManualActions() {
@@ -824,6 +839,7 @@
     }
 
     function refresh() {
+      if (isPageHidden()) return;
       fetchJson(buildLogUrl(LOG_LIVE_LINES, 'friendly', false), function(err, data) {
         if (err || !data || typeof data.log !== 'string') return;
         if (data.channel && data.channel !== logState.channel) return;
@@ -835,7 +851,7 @@
     function startLoop() {
       if (logState.timer) return;
       logState.timer = setInterval(function() {
-        if (logState.refreshing) refresh();
+        if (logState.refreshing && !isPageHidden()) refresh();
       }, 2000);
     }
 
@@ -940,6 +956,9 @@
       stickBottom();
     }
     if (logState.refreshing) refresh();
+    onPageVisible(function() {
+      if (logState.refreshing) refresh();
+    });
     startLoop();
   }
 

--- a/scripts/hot_update.py
+++ b/scripts/hot_update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import os
 import posixpath
@@ -22,6 +23,7 @@ LUCI_BASE_URL = os.environ.get(
 )
 FORCE_LF_TARGETS = {"/etc/init.d/smart_srun", "/usr/bin/srunnet"}
 EXECUTABLE_TARGETS = ["/usr/bin/srunnet", "/etc/init.d/smart_srun"]
+PROBE_ROOT_PREFIX = "/tmp/smart_srun_probe"
 
 RUNTIME_TARGETS = [
     {
@@ -126,6 +128,51 @@ UPLOAD_TARGETS = [
     *LUA_AND_SERVICE_TARGETS,
 ]
 
+LOGGER_PROBE_CODE = r"""
+import sys
+import tempfile
+
+sys.path.insert(0, "usr/lib/smart_srun")
+import logger
+
+logger.LOG_FILE = tempfile.mktemp(prefix="smart_srun_probe_log_", dir="/tmp")
+logger.log(
+    "INFO",
+    "probe",
+    "line1\nline2",
+    password="secret",
+    url="http://x/login",
+)
+data = open(logger.LOG_FILE, "r", encoding="utf-8").read()
+print(data.strip())
+assert "\\nline2" in data
+assert "\nline2" not in data
+assert "secret" not in data
+assert "password=***" in data
+assert data.count("\n") == 1
+"""
+
+
+def _lua_string(value):
+    return json.dumps(str(value), ensure_ascii=True)
+
+
+def build_luci_friendly_probe_code(probe_root):
+    return """
+local PROBE = %s
+package.path = PROBE .. "/usr/lib/lua/?.lua;" .. PROBE .. "/usr/lib/lua/?/init.lua;" .. package.path
+dofile(PROBE .. "/usr/lib/lua/luci/controller/smart_srun.lua")
+local controller = package.loaded["luci.controller.smart_srun"]
+assert(controller and controller.friendly_line)
+local out = controller.friendly_line('[2026-06-01 22:00:00] INFO http_fetch_result url="http://example/login" status_code=200 duration_ms=123 password=*** | ok')
+print(out)
+assert(out:find("URL=http://example/login", 1, true))
+assert(out:find("状态码=200", 1, true))
+assert(out:find("耗时=123ms", 1, true))
+assert(not out:find("password", 1, true))
+assert(not out:find("***", 1, true))
+""" % _lua_string(probe_root)
+
 
 def build_remote_commands():
     python_files = [
@@ -153,6 +200,82 @@ def build_remote_commands():
             "srunnet status",
             "srunnet schools",
             "srunnet schools inspect --selected",
+        ],
+    }
+
+
+def remote_path_for(remote_path, remote_root=None):
+    if not remote_root:
+        return remote_path
+    return posixpath.join(remote_root, str(remote_path).lstrip("/"))
+
+
+def remote_target_paths(remote_root=None):
+    return [
+        {
+            "local": item["local"],
+            "remote": remote_path_for(item["remote"], remote_root),
+            "original_remote": item["remote"],
+        }
+        for item in UPLOAD_TARGETS
+    ]
+
+
+def build_probe_commands(probe_root):
+    targets = remote_target_paths(probe_root)
+    python_files = [
+        item["remote"] for item in targets if item["remote"].endswith(".py")
+    ]
+    python_path = remote_path_for("/usr/lib/smart_srun", probe_root)
+    controller_path = remote_path_for(
+        "/usr/lib/lua/luci/controller/smart_srun.lua", probe_root
+    )
+    schema_path = remote_path_for("/usr/lib/lua/luci/smart_srun/schema.lua", probe_root)
+    model_path = remote_path_for(
+        "/usr/lib/lua/luci/model/cbi/smart_srun.lua", probe_root
+    )
+    init_path = remote_path_for("/etc/init.d/smart_srun", probe_root)
+    return {
+        "probe_checks": [
+            "python3 -m py_compile %s" % " ".join(python_files),
+            "cd %s && PYTHONPATH=%s python3 -B -c %s"
+            % (
+                shlex.quote(probe_root),
+                shlex.quote(python_path),
+                shlex.quote(
+                    "import sys; sys.path.insert(0, 'usr/lib/smart_srun'); "
+                    "import cli; import school_runtime; import schools; "
+                    "import srun_auth; import orchestrator; import snapshot; "
+                    "import daemon; print('runtime-loader-import-ok')"
+                ),
+            ),
+            "cd %s && PYTHONPATH=%s python3 -B logger_probe.py"
+            % (shlex.quote(probe_root), shlex.quote(python_path)),
+            "lua -e %s"
+            % shlex.quote(
+                "package.path='%s/usr/lib/lua/?.lua;%s/usr/lib/lua/?/init.lua;'..package.path; "
+                "assert(loadfile('%s'))"
+                % (probe_root, probe_root, controller_path)
+            ),
+            "lua -e %s"
+            % shlex.quote(
+                "package.path='%s/usr/lib/lua/?.lua;%s/usr/lib/lua/?/init.lua;'..package.path; "
+                "assert(loadfile('%s'))"
+                % (probe_root, probe_root, schema_path)
+            ),
+            "lua -e %s"
+            % shlex.quote(
+                "package.path='%s/usr/lib/lua/?.lua;%s/usr/lib/lua/?/init.lua;'..package.path; "
+                "assert(loadfile('%s'))"
+                % (probe_root, probe_root, model_path)
+            ),
+            "lua %s" % shlex.quote(posixpath.join(probe_root, "luci_friendly_probe.lua")),
+            "sh -n %s" % shlex.quote(init_path),
+            "cd %s && PYTHONPATH=%s python3 -B usr/lib/smart_srun/client.py --version"
+            % (shlex.quote(probe_root), shlex.quote(python_path)),
+        ],
+        "cleanup": [
+            "rm -rf %s /tmp/smart_srun_probe_log_*" % shlex.quote(probe_root),
         ],
     }
 
@@ -202,8 +325,9 @@ def run_remote(ssh, command, timeout=60):
     return exit_code, output, error
 
 
-def ensure_remote_parent_dirs(ssh):
-    parents = sorted({posixpath.dirname(item["remote"]) for item in UPLOAD_TARGETS})
+def ensure_remote_parent_dirs(ssh, targets=None):
+    targets = targets or remote_target_paths()
+    parents = sorted({posixpath.dirname(item["remote"]) for item in targets})
     command = "mkdir -p %s" % " ".join(shlex.quote(path) for path in parents)
     code, output, error = run_remote(ssh, command)
     if code != 0:
@@ -212,12 +336,14 @@ def ensure_remote_parent_dirs(ssh):
         )
 
 
-def upload_files(sftp):
-    for item in UPLOAD_TARGETS:
+def upload_files(sftp, targets=None):
+    targets = targets or remote_target_paths()
+    for item in targets:
         local_path = REPO_ROOT / item["local"]
         remote_path = item["remote"]
         print("UPLOAD %s -> %s" % (item["local"], remote_path))
-        if remote_path in FORCE_LF_TARGETS:
+        original_remote = item.get("original_remote", remote_path)
+        if original_remote in FORCE_LF_TARGETS:
             payload = local_path.read_bytes().replace(b"\r\n", b"\n")
             with sftp.file(remote_path, "wb") as remote_file:
                 remote_file.write(payload)
@@ -225,9 +351,10 @@ def upload_files(sftp):
         sftp.put(str(local_path), remote_path)
 
 
-def restore_executable_permissions(ssh):
+def restore_executable_permissions(ssh, remote_root=None):
+    paths = [remote_path_for(path, remote_root) for path in EXECUTABLE_TARGETS]
     command = "chmod 755 %s" % " ".join(
-        shlex.quote(path) for path in EXECUTABLE_TARGETS
+        shlex.quote(path) for path in paths
     )
     code, output, error = run_remote(ssh, command)
     if code != 0:
@@ -235,6 +362,15 @@ def restore_executable_permissions(ssh):
             "failed to restore executable permissions: %s"
             % (output or error or "no output")
         )
+
+
+def upload_probe_helpers(sftp, probe_root):
+    with sftp.file(posixpath.join(probe_root, "logger_probe.py"), "wb") as remote_file:
+        remote_file.write(LOGGER_PROBE_CODE.encode("utf-8"))
+    with sftp.file(
+        posixpath.join(probe_root, "luci_friendly_probe.lua"), "wb"
+    ) as remote_file:
+        remote_file.write(build_luci_friendly_probe_code(probe_root).encode("utf-8"))
 
 
 def run_command_group(ssh, name, commands, timeout=60):
@@ -254,6 +390,97 @@ def run_command_group(ssh, name, commands, timeout=60):
             )
         results.append({"command": command, "stdout": output, "stderr": error})
     return results
+
+
+def connect_ssh(paramiko, password):
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    print("Connecting to %s as %s" % (ROUTER_HOST, ROUTER_USER))
+    ssh.connect(
+        ROUTER_HOST,
+        username=ROUTER_USER,
+        password=password,
+        look_for_keys=False,
+        allow_agent=False,
+        timeout=10,
+    )
+    return ssh
+
+
+def run_probe(ssh, sftp):
+    probe_root = "%s_%d" % (PROBE_ROOT_PREFIX, int(time.time()))
+    targets = remote_target_paths(probe_root)
+    commands = build_probe_commands(probe_root)
+    try:
+        ensure_remote_parent_dirs(ssh, targets)
+        code, output, error = run_remote(ssh, "mkdir -p %s" % shlex.quote(probe_root))
+        if code != 0:
+            raise RuntimeError(
+                "failed to prepare probe root: %s"
+                % (output or error or "no output")
+            )
+        upload_files(sftp, targets)
+        upload_probe_helpers(sftp, probe_root)
+        restore_executable_permissions(ssh, remote_root=probe_root)
+        run_command_group(ssh, "probe", commands["probe_checks"], timeout=90)
+        print_block("probe root", probe_root)
+        print("PROBE OK")
+        return 0
+    finally:
+        for command in commands["cleanup"]:
+            code, output, error = run_remote(ssh, command, timeout=30)
+            if code != 0:
+                print_block("probe cleanup failed", output or error or "no output")
+
+
+def print_upload_plan(targets):
+    print("== upload targets ==")
+    for item in targets:
+        print("%s -> %s" % (item["local"], item["remote"]))
+
+
+def print_command_plan(commands):
+    print("== remote commands ==")
+    for name, command_list in commands.items():
+        print("[%s]" % name)
+        for command in command_list:
+            print("  %s" % command)
+
+
+def run_dry_run(probe=False):
+    if probe:
+        probe_root = "%s_DRY_RUN" % PROBE_ROOT_PREFIX
+        print("DRY RUN: probe upload and smoke checks")
+        print_block("probe root", probe_root)
+        print_upload_plan(remote_target_paths(probe_root))
+        print("helper -> %s" % posixpath.join(probe_root, "logger_probe.py"))
+        print("helper -> %s" % posixpath.join(probe_root, "luci_friendly_probe.lua"))
+        print_command_plan(build_probe_commands(probe_root))
+        return 0
+
+    print("DRY RUN: production hot update")
+    print_upload_plan(remote_target_paths())
+    print_command_plan(build_remote_commands())
+    print("== luci verification ==")
+    print("Fetch %s/admin/services/smart_srun after restart" % LUCI_BASE_URL)
+    return 0
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser(
+        description="Upload SMART SRun files to an OpenWrt router and run smoke checks."
+    )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="upload to /tmp and run smoke checks without overwriting production files or restarting services",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print planned uploads and remote commands without connecting to the router",
+    )
+    return parser
 
 
 def build_luci_opener():
@@ -351,61 +578,61 @@ def parse_selected_runtime_metadata(inspect_output):
     return payload, descriptors
 
 
-def main():
-    ensure_local_files()
-    password = require_router_password()
-    paramiko = load_paramiko()
+def run_hot_update(ssh, sftp):
     commands = build_remote_commands()
 
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    print("Connecting to %s as %s" % (ROUTER_HOST, ROUTER_USER))
-    ssh.connect(
-        ROUTER_HOST,
-        username=ROUTER_USER,
-        password=password,
-        look_for_keys=False,
-        allow_agent=False,
-        timeout=10,
+    ensure_remote_parent_dirs(ssh)
+    upload_files(sftp)
+    restore_executable_permissions(ssh)
+    print("UPLOAD OK")
+
+    run_command_group(ssh, "syntax", commands["syntax_checks"], timeout=90)
+    run_command_group(ssh, "cleanup", commands["cache_cleanup"], timeout=30)
+    run_command_group(ssh, "restart", commands["restart"], timeout=60)
+    sanity_results = run_command_group(
+        ssh, "sanity", commands["sanity_checks"], timeout=60
     )
 
+    inspect_output = ""
+    for item in sanity_results:
+        if item["command"] == "srunnet schools inspect --selected":
+            inspect_output = item["stdout"].strip()
+            break
+    if not inspect_output:
+        raise RuntimeError("missing selected runtime inspection output")
+
+    metadata, descriptors = parse_selected_runtime_metadata(inspect_output)
+    time.sleep(2)
+    page = verify_luci_page(len(descriptors))
+
+    print_block(
+        "selected runtime metadata",
+        json.dumps(metadata, ensure_ascii=False, indent=2),
+    )
+    print_block(
+        "luci verification",
+        "OK: fetched LuCI page with expected school runtime markers",
+    )
+    print_block("luci page size", str(len(page)))
+    print("HOT UPDATE OK")
+    return 0
+
+
+def main(argv=None):
+    args = build_arg_parser().parse_args(argv)
+    ensure_local_files()
+    if args.dry_run:
+        return run_dry_run(probe=args.probe)
+
+    password = require_router_password()
+    paramiko = load_paramiko()
+
+    ssh = connect_ssh(paramiko, password)
     sftp = ssh.open_sftp()
     try:
-        ensure_remote_parent_dirs(ssh)
-        upload_files(sftp)
-        restore_executable_permissions(ssh)
-        print("UPLOAD OK")
-
-        run_command_group(ssh, "syntax", commands["syntax_checks"], timeout=90)
-        run_command_group(ssh, "cleanup", commands["cache_cleanup"], timeout=30)
-        run_command_group(ssh, "restart", commands["restart"], timeout=60)
-        sanity_results = run_command_group(
-            ssh, "sanity", commands["sanity_checks"], timeout=60
-        )
-
-        inspect_output = ""
-        for item in sanity_results:
-            if item["command"] == "srunnet schools inspect --selected":
-                inspect_output = item["stdout"].strip()
-                break
-        if not inspect_output:
-            raise RuntimeError("missing selected runtime inspection output")
-
-        metadata, descriptors = parse_selected_runtime_metadata(inspect_output)
-        time.sleep(2)
-        page = verify_luci_page(len(descriptors))
-
-        print_block(
-            "selected runtime metadata",
-            json.dumps(metadata, ensure_ascii=False, indent=2),
-        )
-        print_block(
-            "luci verification",
-            "OK: fetched LuCI page with expected school runtime markers",
-        )
-        print_block("luci page size", str(len(page)))
-        print("HOT UPDATE OK")
-        return 0
+        if args.probe:
+            return run_probe(ssh, sftp)
+        return run_hot_update(ssh, sftp)
     finally:
         sftp.close()
         ssh.close()

--- a/tests/test_logger_level.py
+++ b/tests/test_logger_level.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import tempfile
 import unittest
 
 
@@ -88,10 +89,72 @@ class LoggerTests(unittest.TestCase):
         self.assertIn('msg_key="has spaces"', line)
         self.assertIn('empty=""', line)
 
+    def test_control_characters_are_kept_on_one_log_line(self):
+        logger.log("INFO", "e", "first\nsecond", detail="a\tb", raw="x\\y")
+        line = self._emitted[0]
+        self.assertIn("first\\nsecond", line)
+        self.assertIn("detail=a\\tb", line)
+        self.assertIn("raw=x\\\\y", line)
+        self.assertNotIn("\n", line)
+        self.assertNotIn("\t", line)
+
+    def test_append_log_keeps_legacy_lines_single_line(self):
+        logger.append_log("legacy\nmessage\twith controls")
+        line = self._emitted[0]
+        self.assertIn("legacy\\nmessage\\twith controls", line)
+        self.assertNotIn("\n", line)
+        self.assertNotIn("\t", line)
+
+    def test_sensitive_structured_fields_are_redacted(self):
+        logger.set_log_context(session_token="context-secret")
+        logger.log(
+            "INFO",
+            "e",
+            password="plain-secret",
+            chksum="deadbeef",
+            campus_key="wifi-secret",
+            username="alice",
+        )
+        line = self._emitted[0]
+        self.assertIn("password=***", line)
+        self.assertIn("chksum=***", line)
+        self.assertIn("campus_key=***", line)
+        self.assertIn("session_token=***", line)
+        self.assertIn("username=alice", line)
+        self.assertNotIn("plain-secret", line)
+        self.assertNotIn("deadbeef", line)
+        self.assertNotIn("wifi-secret", line)
+        self.assertNotIn("context-secret", line)
+
     def test_timed_context_manager_reports_milliseconds(self):
         with logger.timed() as t:
             time.sleep(0.01)
         self.assertGreaterEqual(t.ms, 5)
+
+    def test_rotate_log_tail_keeps_recent_complete_lines(self):
+        original_file = logger.LOG_FILE
+        original_max = logger.LOG_MAX_BYTES
+        self.addCleanup(setattr, logger, "LOG_FILE", original_file)
+        self.addCleanup(setattr, logger, "LOG_MAX_BYTES", original_max)
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+
+        logger.LOG_FILE = path
+        logger.LOG_MAX_BYTES = 80
+        with open(path, "wb") as f:
+            for idx in range(10):
+                f.write(("line-%02d payload\n" % idx).encode("utf-8"))
+
+        logger._rotate_log_tail()
+
+        with open(path, "rb") as f:
+            data = f.read().decode("utf-8")
+        self.assertTrue(data.startswith("line-"))
+        self.assertIn("line-09 payload\n", data)
+        self.assertNotIn("line-00 payload\n", data)
+        self.assertLessEqual(len(data.encode("utf-8")), logger.LOG_MAX_BYTES // 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_lua_syntax.py
+++ b/tests/test_lua_syntax.py
@@ -1,0 +1,178 @@
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LUA_ROOT = REPO_ROOT / "root" / "usr" / "lib" / "lua" / "luci"
+CONTROLLER_FILE = LUA_ROOT / "controller" / "smart_srun.lua"
+
+
+def lua_string(value):
+    return json.dumps(str(value).replace("\\", "/"), ensure_ascii=False)
+
+
+class LuaSyntaxSmokeTests(unittest.TestCase):
+    def test_shipped_luci_lua_files_parse_with_luac(self):
+        luac = shutil.which("luac")
+        if not luac:
+            self.skipTest("luac is not installed")
+
+        lua_files = sorted(LUA_ROOT.rglob("*.lua"))
+        self.assertTrue(lua_files, "expected shipped LuCI Lua files")
+
+        for path in lua_files:
+            with self.subTest(path=str(path.relative_to(REPO_ROOT))):
+                with (
+                    tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as stdout,
+                    tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as stderr,
+                ):
+                    result = subprocess.run(
+                        [luac, "-p", str(path)],
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout,
+                        stderr=stderr,
+                        text=True,
+                    )
+                    stdout.seek(0)
+                    stderr.seek(0)
+                    output = (stderr.read() or stdout.read()).strip()
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    output,
+                )
+
+    def test_luci_friendly_line_executes_with_lua(self):
+        lua = shutil.which("lua")
+        if not lua:
+            self.skipTest("lua is not installed")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stub_root = Path(temp_dir) / "lua"
+            (stub_root / "luci" / "smart_srun").mkdir(parents=True)
+            (stub_root / "nixio").mkdir(parents=True)
+            (stub_root / "luci" / "http.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "function M.formvalue() return nil end",
+                        "function M.prepare_content() end",
+                        "function M.write() end",
+                        "function M.status() end",
+                        "function M.header() end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (stub_root / "luci" / "jsonc.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "function M.parse() return {} end",
+                        "function M.stringify() return '{}' end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (stub_root / "luci" / "sys.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "function M.exec() return '' end",
+                        "function M.call() return 0 end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (stub_root / "luci" / "util.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "function M.trim(value) return tostring(value or ''):match('^%s*(.-)%s*$') end",
+                        "function M.pcdata(value) return tostring(value or '') end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (stub_root / "nixio" / "fs.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "function M.readfile() return '' end",
+                        "function M.writefile() return true end",
+                        "function M.access() return false end",
+                        "function M.mkdirr() return true end",
+                        "function M.remove() return true end",
+                        "function M.dir() return function() return nil end end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (stub_root / "luci" / "smart_srun" / "schema.lua").write_text(
+                "\n".join(
+                    [
+                        "local M = {}",
+                        "M.POINTER_KEYS = {}",
+                        "M.LIST_KEYS = {}",
+                        "function M.global_scalar_key_set() return {} end",
+                        "function M.with_file_lock(_, callback) return callback() end",
+                        "function M.installed_package_display_text() return 'Bundle 版 v0.0.0-r1' end",
+                        "return M",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            script = """
+package.path = %s .. "/?.lua;" .. %s .. "/?/init.lua;" .. %s .. "/?.lua;" .. %s .. "/?/init.lua;" .. package.path
+_ = function(value) return value end
+entry = function() return {} end
+call = function(value) return value end
+cbi = function(value) return value end
+dofile(%s)
+local controller = package.loaded["luci.controller.smart_srun"]
+assert(controller and controller.friendly_line)
+local out = controller.friendly_line('[2026-06-01 22:00:00] INFO http_fetch_result url="http://example/login" status_code=200 duration_ms=123 password=*** | ok')
+assert(out:find("URL=http://example/login", 1, true), out)
+assert(out:find("状态码=200", 1, true), out)
+assert(out:find("耗时=123ms", 1, true), out)
+assert(not out:find("password", 1, true), out)
+assert(not out:find("***", 1, true), out)
+""" % (
+                lua_string(stub_root),
+                lua_string(stub_root),
+                lua_string(LUA_ROOT.parent),
+                lua_string(LUA_ROOT.parent),
+                lua_string(CONTROLLER_FILE),
+            )
+            script_path = Path(temp_dir) / "friendly_probe.lua"
+            script_path.write_text(script, encoding="utf-8")
+
+            with (
+                tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as stdout,
+                tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as stderr,
+            ):
+                result = subprocess.run(
+                    [lua, str(script_path)],
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout,
+                    stderr=stderr,
+                    text=True,
+                )
+                stdout.seek(0)
+                stderr.seek(0)
+                output = (stderr.read() or stdout.read()).strip()
+            self.assertEqual(result.returncode, 0, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_luci_log_view_refactor.py
+++ b/tests/test_luci_log_view_refactor.py
@@ -50,15 +50,51 @@ class LuciLogViewRefactorTests(unittest.TestCase):
         self.assertIn('if not zh then', self.controller_text)
         self.assertIn('local suffix = extract_structured_suffix(rest, level, event)', self.controller_text)
         self.assertIn('parts[#parts + 1] = " " .. suffix', self.controller_text)
+        self.assertIn('local function parse_structured_fields(rest, level, event)', self.controller_text)
+        self.assertIn('local function append_friendly_fields(parts, field_list, field_map, skipped)', self.controller_text)
         self.assertIn('channel = channel,', self.controller_text)
         self.assertIn('return read_plugin_full_log_text()', self.controller_text)
         self.assertIn('local function resolve_network_source_lines(lines, download_mode)', self.controller_text)
         self.assertIn('local source_lines = requested * 4', self.controller_text)
         self.assertIn('local plugin_text = read_plugin_log_text(source_lines)', self.controller_text)
         self.assertIn('local system_text = read_system_log_text(source_lines)', self.controller_text)
+        self.assertIn('local function tail_text(text, lines)', self.controller_text)
+        self.assertIn('local read_file_tail', self.controller_text)
+        self.assertIn('read_file_tail(LOG_FILE, 1)', self.controller_text)
+        self.assertIn('return read_file_tail(LOG_FILE, lines)', self.controller_text)
+        self.assertNotIn('tail -n 1 /var/log/smart_srun.log', self.controller_text)
+        self.assertIn('"logread -l " .. lines .. " 2>/dev/null"', self.controller_text)
+        self.assertIn('"logread 2>/dev/null"', self.controller_text)
+        self.assertIn('return tail_text(text, lines)', self.controller_text)
+        self.assertNotIn('"logread 2>/dev/null | tail -n " .. lines', self.controller_text)
+
+    def test_friendly_log_translation_preserves_structured_context(self):
+        # Known translated events still need the original structured fields; otherwise
+        # LuCI shows only a friendly description and drops the useful detail.
+        for key, label in [
+            ("url", "URL"),
+            ("status_code", "状态码"),
+            ("duration_ms", "耗时"),
+            ("queue_lag_ms", "排队"),
+            ("bytes_received", "字节"),
+            ("error_code", "错误码"),
+            ("username_reported", "在线账号"),
+            ("bind_ip", "绑定IP"),
+        ]:
+            self.assertIn(f'"{key}"', self.controller_text)
+            self.assertIn(f'{key} = "{label}"', self.controller_text)
+        self.assertIn('append_friendly_fields(parts, field_list, field_map, skip_fields("account", "reason", "attempt"))', self.controller_text)
+        self.assertIn('append_message_detail(parts, rest, has_detail)', self.controller_text)
+        self.assertIn('hidden_friendly_fields', self.controller_text)
+        self.assertIn('sensitive_friendly_key_parts', self.controller_text)
+        self.assertIn('local function is_hidden_friendly_field(key)', self.controller_text)
+        self.assertIn('is_hidden_friendly_field(key)', self.controller_text)
 
     def test_cbi_log_panel_renders_channel_switcher_and_toolbar(self):
-        self.assertIn('tail -n 100 /var/log/smart_srun.log', self.cbi_text)
+        self.assertIn('local LOG_FILE = "/var/log/smart_srun.log"', self.cbi_text)
+        self.assertIn('local function read_file_tail(path, lines)', self.cbi_text)
+        self.assertIn('local t = read_file_tail(LOG_FILE, 100)', self.cbi_text)
+        self.assertNotIn('tail -n 100 /var/log/smart_srun.log', self.cbi_text)
         self.assertIn('log_controller.friendly_log_text(t)', self.cbi_text)
         self.assertIn('data-channel="plugin"', self.cbi_text)
         self.assertIn('data-channel="network"', self.cbi_text)
@@ -128,6 +164,18 @@ class LuciLogViewRefactorTests(unittest.TestCase):
         self.assertIn("document.addEventListener('change'", self.js_text)
         self.assertIn("document.addEventListener('cbi-dropdown-change'", self.js_text)
         self.assertIn('applyDisplayLevel', self.js_text)
+
+    def test_js_skips_background_polling_when_page_hidden(self):
+        self.assertIn('function isPageHidden()', self.js_text)
+        self.assertIn('document.hidden === true', self.js_text)
+        self.assertIn('document.webkitHidden === true', self.js_text)
+        self.assertIn('function onPageVisible(callback)', self.js_text)
+        self.assertIn("document.addEventListener('visibilitychange'", self.js_text)
+        self.assertIn('if (!isPageHidden()) refreshOverview();', self.js_text)
+        self.assertIn('if (isPageHidden()) return;', self.js_text)
+        self.assertIn('if (logState.refreshing && !isPageHidden()) refresh();', self.js_text)
+        self.assertIn('onPageVisible(refreshOverview)', self.js_text)
+        self.assertIn('onPageVisible(function() {', self.js_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_remaining_review_items.py
+++ b/tests/test_remaining_review_items.py
@@ -21,6 +21,38 @@ import wireless
 
 
 class NetworkBindIpTests(unittest.TestCase):
+    def test_get_ipv4_falls_back_to_ip_addr_when_ubus_json_is_invalid(self):
+        calls = []
+
+        def fake_run(cmd):
+            calls.append(cmd)
+            if cmd[:3] == ["ubus", "call", "network.interface.wan"]:
+                return True, "{not-json"
+            return True, "2: eth0    inet 10.0.0.9/24 brd 10.0.0.255 scope global eth0"
+
+        with mock.patch.object(network, "run_cmd", side_effect=fake_run):
+            ip = network.get_ipv4_from_network_interface("wan")
+
+        self.assertEqual(ip, "10.0.0.9")
+        self.assertEqual(
+            calls[-1],
+            ["ip", "-4", "-o", "addr", "show", "dev", "wan"],
+        )
+
+    def test_get_ipv4_does_not_swallow_unexpected_parse_errors(self):
+        with (
+            mock.patch.object(
+                network, "run_cmd", return_value=(True, '{"ipv4-address": []}')
+            ),
+            mock.patch.object(
+                network,
+                "_parse_network_interface_status",
+                side_effect=RuntimeError("unexpected"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "unexpected"):
+                network.get_ipv4_from_network_interface("wan")
+
     def test_http_get_skips_urllib_when_bind_ip_is_explicit(self):
         with (
             mock.patch.object(
@@ -164,6 +196,18 @@ class ConfigLockingTests(unittest.TestCase):
             daemon._config_set(["enabled=1"])
 
         updater.assert_called_once()
+
+    def test_invalid_json_config_still_falls_back_to_empty_payload(self):
+        with open(self.config_path, "w", encoding="utf-8") as wf:
+            wf.write("{not-json")
+
+        self.assertEqual(config.load_json_raw_config(), {})
+        self.assertEqual(config.load_json_file(self.config_path), {})
+
+    def test_json_config_read_does_not_swallow_unexpected_open_errors(self):
+        with mock.patch("builtins.open", side_effect=RuntimeError("unexpected")):
+            with self.assertRaisesRegex(RuntimeError, "unexpected"):
+                config.load_json_raw_config()
 
 
 class WirelessSanitizationTests(unittest.TestCase):

--- a/tests/test_school_runtime_cli.py
+++ b/tests/test_school_runtime_cli.py
@@ -621,6 +621,140 @@ class HotUpdateScriptTests(unittest.TestCase):
 
         self.assertIn("SMARTSRUN_ROUTER_PASSWORD", str(exc.exception))
 
+    def test_hot_update_probe_arg_is_explicit(self):
+        hot_update = load_hot_update_module(self)
+
+        self.assertFalse(hot_update.build_arg_parser().parse_args([]).probe)
+        self.assertTrue(hot_update.build_arg_parser().parse_args(["--probe"]).probe)
+        self.assertTrue(hot_update.build_arg_parser().parse_args(["--dry-run"]).dry_run)
+        parsed = hot_update.build_arg_parser().parse_args(["--probe", "--dry-run"])
+        self.assertTrue(parsed.probe)
+        self.assertTrue(parsed.dry_run)
+
+    def test_hot_update_probe_remote_paths_are_rebased_to_tmp(self):
+        hot_update = load_hot_update_module(self)
+
+        self.assertEqual(
+            hot_update.remote_path_for("/usr/bin/srunnet", "/tmp/probe"),
+            "/tmp/probe/usr/bin/srunnet",
+        )
+        targets = hot_update.remote_target_paths("/tmp/probe")
+        self.assertTrue(targets)
+        self.assertTrue(
+            all(item["remote"].startswith("/tmp/probe/") for item in targets)
+        )
+        self.assertIn(
+            {
+                "local": "root/usr/bin/srunnet",
+                "remote": "/tmp/probe/usr/bin/srunnet",
+                "original_remote": "/usr/bin/srunnet",
+            },
+            targets,
+        )
+
+    def test_hot_update_probe_commands_do_not_restart_production_services(self):
+        hot_update = load_hot_update_module(self)
+
+        commands = hot_update.build_probe_commands("/tmp/probe")
+        probe_text = "\n".join(commands["probe_checks"])
+        cleanup_text = "\n".join(commands["cleanup"])
+
+        self.assertIn("/tmp/probe/usr/lib/smart_srun/school_runtime.py", probe_text)
+        self.assertIn(
+            "/tmp/probe/usr/lib/lua/luci/controller/smart_srun.lua", probe_text
+        )
+        self.assertIn("logger_probe.py", probe_text)
+        self.assertIn("luci_friendly_probe.lua", probe_text)
+        self.assertIn("client.py --version", probe_text)
+        self.assertIn("rm -rf /tmp/probe", cleanup_text)
+        self.assertNotIn("/etc/init.d/smart_srun restart", probe_text)
+        self.assertNotIn("/etc/init.d/uwsgi restart", probe_text)
+
+    def test_hot_update_main_probe_dispatches_without_hot_update(self):
+        hot_update = load_hot_update_module(self)
+
+        class FakeSftp(object):
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class FakeSsh(object):
+            def __init__(self):
+                self.sftp = FakeSftp()
+                self.closed = False
+
+            def open_sftp(self):
+                return self.sftp
+
+            def close(self):
+                self.closed = True
+
+        fake_ssh = FakeSsh()
+        fake_paramiko = object()
+
+        with (
+            mock.patch.object(hot_update, "ensure_local_files") as ensure_files,
+            mock.patch.object(
+                hot_update, "require_router_password", return_value="secret"
+            ) as require_password,
+            mock.patch.object(
+                hot_update, "load_paramiko", return_value=fake_paramiko
+            ) as load_paramiko,
+            mock.patch.object(
+                hot_update, "connect_ssh", return_value=fake_ssh
+            ) as connect_ssh,
+            mock.patch.object(hot_update, "run_probe", return_value=0) as run_probe,
+            mock.patch.object(hot_update, "run_hot_update") as run_hot_update,
+        ):
+            code = hot_update.main(["--probe"])
+
+        self.assertEqual(code, 0)
+        ensure_files.assert_called_once_with()
+        require_password.assert_called_once_with()
+        load_paramiko.assert_called_once_with()
+        connect_ssh.assert_called_once_with(fake_paramiko, "secret")
+        run_probe.assert_called_once_with(fake_ssh, fake_ssh.sftp)
+        run_hot_update.assert_not_called()
+        self.assertTrue(fake_ssh.sftp.closed)
+        self.assertTrue(fake_ssh.closed)
+
+    def test_hot_update_main_dry_run_does_not_connect_or_require_password(self):
+        hot_update = load_hot_update_module(self)
+
+        with (
+            mock.patch.object(hot_update, "ensure_local_files") as ensure_files,
+            mock.patch.object(hot_update, "require_router_password") as require_password,
+            mock.patch.object(hot_update, "load_paramiko") as load_paramiko,
+            mock.patch.object(hot_update, "connect_ssh") as connect_ssh,
+            mock.patch.object(hot_update, "run_dry_run", return_value=0) as run_dry_run,
+        ):
+            code = hot_update.main(["--probe", "--dry-run"])
+
+        self.assertEqual(code, 0)
+        ensure_files.assert_called_once_with()
+        run_dry_run.assert_called_once_with(probe=True)
+        require_password.assert_not_called()
+        load_paramiko.assert_not_called()
+        connect_ssh.assert_not_called()
+
+    def test_hot_update_probe_dry_run_prints_tmp_plan_without_restarts(self):
+        hot_update = load_hot_update_module(self)
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            code = hot_update.run_dry_run(probe=True)
+
+        text = stdout.getvalue()
+        self.assertEqual(code, 0)
+        self.assertIn("DRY RUN: probe upload and smoke checks", text)
+        self.assertIn("/tmp/smart_srun_probe_DRY_RUN/usr/bin/srunnet", text)
+        self.assertIn("logger_probe.py", text)
+        self.assertIn("luci_friendly_probe.lua", text)
+        self.assertNotIn("/etc/init.d/smart_srun restart", text)
+        self.assertNotIn("/etc/init.d/uwsgi restart", text)
+
 
 class DaemonStartupStateTests(unittest.TestCase):
     def test_run_daemon_preserves_pending_action_context_on_startup(self):

--- a/tests/test_school_runtime_config.py
+++ b/tests/test_school_runtime_config.py
@@ -286,6 +286,26 @@ class SchoolRuntimeConfigTests(unittest.TestCase):
 
         self.assertEqual("alice", loaded["username"])
 
+    def test_school_metadata_lookup_error_falls_back_to_minimal_metadata(self):
+        with mock.patch(
+            "schools.get_school_metadata",
+            side_effect=LookupError("missing runtime-school"),
+        ):
+            metadata = config._get_school_metadata({"school": "runtime-school"})
+
+        self.assertEqual(
+            {"short_name": "runtime-school", "no_suffix_operators": ["xn"]},
+            metadata,
+        )
+
+    def test_school_metadata_does_not_swallow_unexpected_runtime_errors(self):
+        with mock.patch(
+            "schools.get_school_metadata",
+            side_effect=RuntimeError("unexpected metadata failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "unexpected metadata failure"):
+                config._get_school_metadata({"school": "runtime-school"})
+
     def test_luci_contract_normalizes_bool_descriptor_defaults(self):
         contract = config.build_school_runtime_luci_contract(
             {"school": "jxnu", config.SCHOOL_EXTRA_KEY: {}},


### PR DESCRIPTION
## Summary
- harden structured logging so control characters stay on one log line and sensitive fields are redacted before LuCI rendering
- improve LuCI log tailing and rendering while reducing shell/process overhead
- add hot-update `--dry-run` and non-destructive `--probe` modes, plus stronger remote smoke checks
- add OpenWrt/Lua syntax smoke coverage and move pytest cache to `.cache/pytest`
- document local tool requirements, smoke tests, and router hot-update workflow

## Router hot update
- Ran production `python scripts/hot_update.py` against router `10.0.0.2` after operator approval
- Upload, remote syntax checks, service restarts, `srunnet status`, school metadata checks, and LuCI page verification all passed
- Router status after deploy: online wired campus-network mode, internet reachable, daemon running

## Verification
- `python -m pytest tests/ -v` (`155 passed, 18 subtests passed`)
- `ruff check root/usr/lib/smart_srun/`
- `git diff --check` (only CRLF conversion warnings on Windows)