### PR TITLE
Fix CI: mock inflight action markers in runtime action tests

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -91,9 +91,12 @@ jobs:
         run: |
           BASE_VERSION='${{ github.event.inputs.version }}'
           BASE_VERSION="${BASE_VERSION#v}"
-          VERSION="${BASE_VERSION}-b${{ github.event.inputs.beta }}"
           if [ "${{ matrix.format }}" = "apk" ]; then
-            VERSION="${VERSION//-/_}"
+            # apk-tools 只接受 _alpha/_beta/_pre/_rc/... 后缀，"_b<N>" 非法会导致
+            # mkpkg 报 "package version is invalid" 而整条预发布流水线无法发布。
+            VERSION="${BASE_VERSION}_beta${{ github.event.inputs.beta }}"
+          else
+            VERSION="${BASE_VERSION}-b${{ github.event.inputs.beta }}"
           fi
           awk -v ver="$VERSION" '
             BEGIN { replaced=0 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+# Runs the checks CLAUDE.md / CONTRIBUTING mandate on every push and PR.
+# The build workflows only copy files (Build/Compile is empty), so without this
+# a broken runtime (syntax error, failing test) would package and publish clean.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NO_COLOR: "1"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python tooling
+        run: python -m pip install --upgrade pip pytest ruff
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Lua (for luac syntax checks)
+        run: sudo apt-get update && sudo apt-get install -y lua5.1
+
+      - name: Ruff
+        run: ruff check root/usr/lib/smart_srun/
+
+      - name: Node syntax check (LuCI frontend)
+        run: node --check root/www/luci-static/resources/smart_srun.js
+
+      - name: Pytest
+        run: python -m pytest tests/ -v

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-RUNTIME_DEPENDS:=+python3-light
-LUCI_FILE_DEPENDS:=
+RUNTIME_DEPENDS:=+python3-light +python3-urllib
+LUCI_FILE_DEPENDS:=+luci-base +luci-compat
 LUCI_PACKAGE_DEPENDS:=+smart-srun $(LUCI_FILE_DEPENDS)
 BUNDLE_DEPENDS:=$(RUNTIME_DEPENDS) $(LUCI_FILE_DEPENDS)
 

--- a/doc/school-presets.json
+++ b/doc/school-presets.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-06-26",
+  "updated_at": "2026-07-19",
   "source": "https://github.com/matthewlu070111/smart-srun/issues",
   "schools": [
     {
@@ -8,6 +8,7 @@
       "name": "江西师范大学",
       "status": "active",
       "description": "江西师范大学预设。",
+      "doc_url": "https://github.com/matthewlu070111/smart-srun/blob/main/doc/jxnu.md",
       "defaults": {
         "base_url": "http://172.17.1.2",
         "ac_id": "1",
@@ -146,6 +147,33 @@
       ],
       "contributors": ["@zhaogods"],
       "source_issue": "https://github.com/matthewlu070111/smart-srun/issues/20"
+    },
+    {
+      "id": "nchu",
+      "name": "南昌航空大学（前湖校区）",
+      "status": "active",
+      "description": "环境信息来自 #22 真实抓包；电信运营商后缀尚未验证（捕获脚本上报值与实际不符），选择后请按提示手动确认。",
+      "defaults": {
+        "base_url": "http://10.1.88.4",
+        "ac_id": "1",
+        "ssid": "NCHU_Wireless",
+        "access_mode": "wifi"
+      },
+      "observed_login_shape": {
+        "n": "200",
+        "type": "1",
+        "enc": "srun_bx1",
+        "info_prefix": "SRBX1",
+        "double_stack": "0",
+        "os": "Mac OS",
+        "name": "Macintosh"
+      },
+      "operators": [
+        {"suffix": "??", "label": "中国电信"},
+        {"suffix": "", "label": "校园网"}
+      ],
+      "contributors": ["@REALBochengWen"],
+      "source_issue": "https://github.com/matthewlu070111/smart-srun/issues/22"
     },
     {
       "id": "hsyu",

--- a/root/etc/init.d/smart_srun
+++ b/root/etc/init.d/smart_srun
@@ -19,7 +19,9 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PYTHON_BIN" -B "$PROG" daemon
-	procd_set_param respawn 3600 5 5
+	# retry=0：无限重生。手动动作触发的 restart 叠加曾把 5 次预算烧光，
+	# 之后守护进程彻底死透、只能重启路由器。
+	procd_set_param respawn 3600 5 0
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance

--- a/root/usr/lib/lua/luci/controller/smart_srun.lua
+++ b/root/usr/lib/lua/luci/controller/smart_srun.lua
@@ -9,9 +9,10 @@ local schema = require "luci.smart_srun.schema"
 
 local STATE_FILE = "/var/run/smart_srun/state.json"
 local ACTION_FILE = "/var/run/smart_srun/action.json"
+local INFLIGHT_ACTION_FILE = "/var/run/smart_srun/action_inflight.json"
 local LOG_FILE = "/var/log/smart_srun.log"
 local restore_manual_guarded_enabled
-local ACTION_STALE_SECONDS = 20
+local ACTION_STALE_SECONDS = 90
 local LOG_TAIL_SOURCE_LINES = 2000
 
 local NETWORK_EVENTS = {
@@ -29,6 +30,8 @@ local NETWORK_EVENTS = {
     srun_online_result = true,
     ip_wait_progress = true,
     ip_wait_result = true,
+    dhcp_kick = true,
+    sta_iface_up = true,
     wifi_reload = true,
     sta_section_disabled = true,
     uci_wireless_update = true,
@@ -137,7 +140,18 @@ local function write_json_file(path, payload)
     if dir and not fs.access(dir) then
         fs.mkdirr(dir)
     end
-    fs.writefile(path, (jsonc.stringify(payload) or "{}") .. "\n")
+    -- 原子写：先写临时文件再 rename，避免守护进程读到截断中的半截 JSON
+    -- （撕裂读会被当成空动作，进而误删刚入队的 action.json）。
+    local body = (jsonc.stringify(payload) or "{}") .. "\n"
+    local tmp = path .. ".tmp"
+    if fs.writefile(tmp, body) then
+        if not fs.rename(tmp, path) then
+            fs.writefile(path, body)
+            fs.remove(tmp)
+        end
+    else
+        fs.writefile(path, body)
+    end
 end
 
 local function remove_file(path)
@@ -180,6 +194,9 @@ local function handle_force_stop()
     sys.call("/etc/init.d/smart_srun stop >/dev/null 2>&1")
     local killed = force_stop_client_processes()
     remove_file(ACTION_FILE)
+    -- 强停是用户明确取消动作，必须一并清掉执行中标记，
+    -- 否则下次服务重启时守护进程会把被取消的动作重新排队执行。
+    remove_file(INFLIGHT_ACTION_FILE)
 
     local state = read_json_file(STATE_FILE)
     restore_manual_guarded_enabled(state)
@@ -201,7 +218,19 @@ local function current_pending_runtime_action()
     if queued ~= "" then
         local requested_at = tonumber(action.requested_at) or 0
         if requested_at > 0 and (os.time() - requested_at) >= ACTION_STALE_SECONDS then
+            -- 丢弃滞留动作时必须同步收敛 state，否则 action_result 会一直停在
+            -- pending，界面永远显示“待执行”（旧版正是这样卡死的）。
             remove_file(ACTION_FILE)
+            local state = read_json_file(STATE_FILE)
+            if tostring(state.action_result or "") == "pending" then
+                state.message = string.format("动作 %s 长时间未被守护进程接取，已取消，请重试", queued)
+                state.pending_action = ""
+                state.action_result = "error"
+                state.action_started_at = 0
+                state.last_action = queued
+                state.last_action_ts = os.time()
+                write_json_file(STATE_FILE, state)
+            end
         else
             return queued
         end
@@ -476,7 +505,13 @@ function action_enqueue()
                 local idx = find_index_by_id(cfg.campus_accounts, id)
                 if idx then
                     item.id = id
-                    cfg.campus_accounts[idx] = item
+                    -- 浅合并：以现有账号为基底，仅覆盖弹窗提交的字段，保留 Python 侧
+                    -- 写入但表单未提交的字段（如 encryption/key 及未来新增字段），
+                    -- 避免每次在网页编辑都把这些字段清空。
+                    local merged = cfg.campus_accounts[idx]
+                    if type(merged) ~= "table" then merged = {} end
+                    for k, v in pairs(item) do merged[k] = v end
+                    cfg.campus_accounts[idx] = merged
                     ok = true; message = "已更新"; need_restart = true
                 else
                     ok = false; message = "未找到 ID: " .. id
@@ -507,7 +542,11 @@ function action_enqueue()
                 local idx = find_index_by_id(cfg.hotspot_profiles, id)
                 if idx then
                     item.id = id
-                    cfg.hotspot_profiles[idx] = item
+                    -- 同 edit_campus：浅合并保留表单未提交的既有字段。
+                    local merged = cfg.hotspot_profiles[idx]
+                    if type(merged) ~= "table" then merged = {} end
+                    for k, v in pairs(item) do merged[k] = v end
+                    cfg.hotspot_profiles[idx] = merged
                     ok = true; message = "已更新"; need_restart = true
                 else
                     ok = false; message = "未找到 ID: " .. id
@@ -602,11 +641,13 @@ local event_zh = {
     login_success       = "登录成功",
     login_failed        = "登录失败",
     retry_scheduled     = "即将重试",
+    retry_interrupted   = "重试被中断",
     retry_success       = "重试成功",
     retry_failed        = "重试失败",
     retry_stopped       = "停止重试",
     disconnect_detected = "检测到断线",
     status_check_error  = "状态检测异常",
+    online_account_mismatch = "在线账号与配置不符",
     logout_request      = "正在登出",
     logout_success      = "登出成功",
     logout_failed       = "登出失败",
@@ -619,6 +660,8 @@ local event_zh = {
     action_result       = "操作结果",
     action_started      = "开始执行动作",
     action_unknown      = "未知操作",
+    action_requeued     = "动作重新排队",
+    action_interrupted  = "动作已中断",
     switch_progress     = "切换进度",
     quiet_enter         = "进入夜间停用",
     quiet_exit          = "退出夜间停用",
@@ -638,6 +681,7 @@ local event_zh = {
     config_loaded       = "配置已加载",
     status_query        = "状态查询",
     update_status       = "更新状态",
+    presets_refresh     = "学校预设刷新",
     -- 重试与生命周期
     retry_cycle_start   = "进入重试循环",
     retry_cycle_end     = "重试循环结束",
@@ -654,6 +698,8 @@ local event_zh = {
     sta_section_disabled = "已禁用 STA 配置段",
     ip_wait_progress    = "等待 IPv4 中",
     ip_wait_result      = "IPv4 等待结果",
+    dhcp_kick           = "重新触发 DHCP",
+    sta_iface_up        = "拉起 STA 网络接口",
     runtime_mode_detect = "检测运行模式",
     profile_rebuild     = "重建无线配置",
     uci_wireless_update = "更新 UCI 无线配置",

--- a/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
+++ b/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
@@ -302,10 +302,9 @@ local RADIO_CHOICES = load_radio_choices()
 local function render_school_info_html(schools, current_school)
     local helper_prefix = "如果该配置无法在您的学校使用，请直接前往"
     local helper_suffix = "提交 Issue 或 PR"
-    local helper_link = "https://github.com/matthewlu070111/luci-app-smart-srun"
-    local doc_base = "https://github.com/matthewlu070111/smart-srun/blob/main/doc/"
-    local short = tostring(current_school or "")
-    local doc_url = doc_base .. util.pcdata(short) .. ".md"
+    local helper_link = "https://github.com/matthewlu070111/smart-srun"
+    -- 初始渲染统一指向 doc 目录（永不 404）；前端 JS 会按预设的 doc_url 覆写为具体文档。
+    local doc_url = "https://github.com/matthewlu070111/smart-srun/tree/main/doc"
     local js_data = jsonc.stringify(schools or {}) or "[]"
 
     return string.format([[
@@ -922,9 +921,10 @@ end
 retry_max_cooldown_seconds.placeholder = "600"
 bind_text(retry_max_cooldown_seconds, "retry_max_cooldown_seconds", validate_non_negative_number)
 
-switch_ready_timeout_seconds = s:taboption("advanced", Value, "switch_ready_timeout_seconds", "切网完成等待时间（秒）")
+switch_ready_timeout_seconds = s:taboption("advanced", Value, "switch_ready_timeout_seconds", "切网完成等待时间（秒）",
+    "切换后等待获取 IPv4 的最长时间；部分学校 DHCP 较慢（如出现“未获取到IPv4地址”可调大）")
 switch_ready_timeout_seconds.datatype = "uinteger"
-switch_ready_timeout_seconds.placeholder = "12"
+switch_ready_timeout_seconds.placeholder = "30"
 bind_text(switch_ready_timeout_seconds, "switch_ready_timeout_seconds")
 
 manual_terminal_check_max_attempts = s:taboption("advanced", Value, "manual_terminal_check_max_attempts", "手动登录/登出终态最大检查次数")

--- a/root/usr/lib/smart_srun/cli.py
+++ b/root/usr/lib/smart_srun/cli.py
@@ -690,7 +690,7 @@ def main():
     if args.command == "switch":
         cfg = daemon.load_config()
         expect_hotspot = args.target == "hotspot"
-        _, message = daemon.run_switch(cfg, expect_hotspot=expect_hotspot)
+        ok, message = daemon.run_switch(cfg, expect_hotspot=expect_hotspot)
         daemon.log(
             "INFO",
             "action_result",
@@ -698,6 +698,8 @@ def main():
             action="switch_%s" % args.target,
         )
         print(message)
+        if not ok:
+            raise SystemExit(1)
         return
 
     if args.command == "config":

--- a/root/usr/lib/smart_srun/config.py
+++ b/root/usr/lib/smart_srun/config.py
@@ -36,6 +36,7 @@ timed = _logger.timed
 JSON_CONFIG_FILE = "/usr/lib/smart_srun/config.json"
 STATE_FILE = "/var/run/smart_srun/state.json"
 ACTION_FILE = "/var/run/smart_srun/action.json"
+INFLIGHT_ACTION_FILE = "/var/run/smart_srun/action_inflight.json"
 CONNECTIVITY_CACHE_SECONDS = 15
 SWITCH_DELAY_SECONDS = 2
 SSID_READY_TIMEOUT_SECONDS = 12
@@ -154,7 +155,7 @@ def _load_defaults():
         "backoff_max_duration": "600",
         "retry_cooldown_seconds": "10",
         "retry_max_cooldown_seconds": "600",
-        "switch_ready_timeout_seconds": "12",
+        "switch_ready_timeout_seconds": "30",
         "manual_terminal_check_max_attempts": "5",
         "manual_terminal_check_interval_seconds": "2",
         "hotspot_failback_enabled": "1",
@@ -220,12 +221,15 @@ def _exclusive_file_lock(path):
         except ImportError:
             fcntl_mod = None
         if fcntl_mod is not None:
-            fcntl_mod.flock(lock_file.fileno(), fcntl_mod.LOCK_EX)
+            # 用 lockf（POSIX 记录锁），与 LuCI 侧 nixio 的 lockf 是同一类锁，
+            # 才能真正互斥；此前用 flock（BSD 锁）与 nixio 互不阻塞，config.json
+            # 的读改写在 Python 与 Lua 之间形同无锁。
+            fcntl_mod.lockf(lock_file.fileno(), fcntl_mod.LOCK_EX)
         yield lock_file
     finally:
         if fcntl_mod is not None:
             try:
-                fcntl_mod.flock(lock_file.fileno(), fcntl_mod.LOCK_UN)
+                fcntl_mod.lockf(lock_file.fileno(), fcntl_mod.LOCK_UN)
             except OSError:
                 pass
         lock_file.close()
@@ -576,10 +580,14 @@ def begin_manual_login_service_guard():
         return False, previous_enabled
 
     set_json_scalar_config("enabled", "0")
-    runtime_state = load_runtime_state()
-    runtime_state["manual_service_guard_active"] = True
-    runtime_state["manual_service_enabled_before"] = previous_enabled
-    save_runtime_state(runtime_state)
+
+    def _apply(payload):
+        payload["manual_service_guard_active"] = True
+        payload["manual_service_enabled_before"] = previous_enabled
+        payload["updated_at"] = int(time.time())
+        return payload
+
+    update_json_file(STATE_FILE, _apply)
     return True, previous_enabled
 
 
@@ -594,9 +602,13 @@ def restore_manual_login_service_guard(clear_only=False):
     if (not clear_only) and previous_enabled:
         set_json_scalar_config("enabled", previous_enabled)
 
-    runtime_state["manual_service_guard_active"] = False
-    runtime_state["manual_service_enabled_before"] = ""
-    save_runtime_state(runtime_state)
+    def _apply(payload):
+        payload["manual_service_guard_active"] = False
+        payload["manual_service_enabled_before"] = ""
+        payload["updated_at"] = int(time.time())
+        return payload
+
+    update_json_file(STATE_FILE, _apply)
     return True, previous_enabled
 
 
@@ -637,12 +649,18 @@ def save_runtime_state(state):
 
 
 def save_runtime_status(message, state=None, **extra):
-    payload = load_runtime_state()
-    if state:
-        payload.update(state)
-    payload.update(extra)
-    payload["message"] = str(message or "")
-    save_runtime_state(payload)
+    # 原子 RMW：在 STATE_FILE 锁内重读磁盘、合并本进程的 state/extra 后写回，
+    # 避免与另一进程（如 CLI relogin 写入 manual_service_guard_active）的
+    # 无锁读-改-写交错，把对方刚写入的持久字段覆盖丢失。
+    def _apply(payload):
+        if state:
+            payload.update(state)
+        payload.update(extra)
+        payload["message"] = str(message or "")
+        payload["updated_at"] = int(time.time())
+        return payload
+
+    update_json_file(STATE_FILE, _apply)
 
 
 # ---------------------------------------------------------------------------
@@ -665,11 +683,15 @@ def queue_runtime_action(action):
 
 
 def pop_runtime_action():
-    payload = load_json_file(ACTION_FILE)
-    try:
-        os.remove(ACTION_FILE)
-    except OSError:
-        pass
+    # 在 ACTION_FILE 锁内读+删，且仅当解析出 action 时才删除：
+    # 配合 LuCI 侧的原子写，避免撕裂/空读时把刚入队的动作连文件一起删掉。
+    with _exclusive_file_lock(ACTION_FILE):
+        payload = _load_json_file_unlocked(ACTION_FILE)
+        if isinstance(payload, dict) and payload.get("action"):
+            try:
+                os.remove(ACTION_FILE)
+            except OSError:
+                pass
     if isinstance(payload, dict) and payload.get("action"):
         requested_at = int(payload.get("requested_at") or 0)
         lag_ms = int(max(0, time.time() - requested_at) * 1000) if requested_at else 0
@@ -681,6 +703,51 @@ def pop_runtime_action():
             lag_ms=lag_ms,
         )
     return payload if isinstance(payload, dict) else {}
+
+
+def requeue_runtime_action(payload):
+    """把中断的动作原样写回队列，保留 requeue_count 等附加字段。
+
+    requested_at 必须刷新：LuCI 侧会把滞留超过一定时长的队列文件当作
+    死队列丢弃，沿用旧时间戳会让刚重排的动作立刻被判定为滞留。
+    """
+    data = dict(payload or {})
+    data["action"] = str(data.get("action") or "").strip()
+    if not data["action"]:
+        return
+    data["requested_at"] = int(time.time())
+    save_json_file(ACTION_FILE, data)
+    log(
+        "INFO",
+        "action_requeued",
+        "requeued interrupted action",
+        action=data["action"],
+        requeue_count=int(data.get("requeue_count") or 0),
+    )
+
+
+def mark_inflight_action(payload):
+    """动作出队后、执行前落盘一个执行中标记；执行结束后清除。
+
+    守护进程若在执行途中被杀（例如再次点击手动动作触发的 service restart），
+    重启后可凭该标记把动作重新排队一次，避免动作凭空丢失、界面卡在待执行。
+    """
+    data = dict(payload or {})
+    if not str(data.get("action") or "").strip():
+        return
+    save_json_file(INFLIGHT_ACTION_FILE, data)
+
+
+def load_inflight_action():
+    payload = load_json_file(INFLIGHT_ACTION_FILE)
+    return payload if isinstance(payload, dict) else {}
+
+
+def clear_inflight_action():
+    try:
+        os.remove(INFLIGHT_ACTION_FILE)
+    except OSError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -722,32 +789,34 @@ def _normalize_info_prefix(value, default_value=DEFAULT_INFO_PREFIX):
 
 
 def _apply_login_shape(cfg, campus):
+    # 账号字段存为空字符串时视同未设置，回落到 legacy 全局值，保持
+    # account > legacy global > default 三级优先级。
     cfg["n"] = _login_shape_number(
-        campus.get("n", cfg.get("n", "")),
+        campus.get("n") or cfg.get("n", ""),
         DEFAULT_LOGIN_N,
     )
     cfg["type"] = _login_shape_number(
-        campus.get("type", cfg.get("type", "")),
+        campus.get("type") or cfg.get("type", ""),
         DEFAULT_LOGIN_TYPE,
     )
     cfg["enc"] = _login_shape_text(
-        campus.get("enc", cfg.get("enc", "")),
+        campus.get("enc") or cfg.get("enc", ""),
         DEFAULT_LOGIN_ENC,
     )
     cfg["info_prefix"] = _normalize_info_prefix(
-        campus.get("info_prefix", cfg.get("info_prefix", "")),
+        campus.get("info_prefix") or cfg.get("info_prefix", ""),
         DEFAULT_INFO_PREFIX,
     )
     cfg["double_stack"] = _login_shape_number(
-        campus.get("double_stack", cfg.get("double_stack", "")),
+        campus.get("double_stack") or cfg.get("double_stack", ""),
         DEFAULT_DOUBLE_STACK,
     )
     cfg["login_os"] = _login_shape_text(
-        campus.get("login_os", cfg.get("login_os", "")),
+        campus.get("login_os") or cfg.get("login_os", ""),
         DEFAULT_LOGIN_OS,
     )
     cfg["login_name"] = _login_shape_text(
-        campus.get("login_name", cfg.get("login_name", "")),
+        campus.get("login_name") or cfg.get("login_name", ""),
         DEFAULT_LOGIN_NAME,
     )
     return cfg
@@ -1019,6 +1088,75 @@ def resolve_active_items(cfg):
 # ---------------------------------------------------------------------------
 
 
+def _reconcile_selection_pointers(raw):
+    """收敛历史遗留的 default/active 选择指针分裂。
+
+    v1.3.4 的“设为默认”只写 default_*_id（提示“手动登录后生效”），active 仍指向
+    旧账号；此后所有自动路径（掉线重连、门户注销后的自动重登）按 active 解析，
+    会持续用错账号（例如丢失运营商后缀、落到校园网/学生侧）。现行代码所有写入
+    点都成对更新两个指针，因此不一致只可能是旧数据，以 default 为准收敛。
+    """
+    changed = False
+    pairs = (
+        ("campus_accounts", "default_campus_id", "active_campus_id"),
+        ("hotspot_profiles", "default_hotspot_id", "active_hotspot_id"),
+    )
+    for list_key, default_key, active_key in pairs:
+        items = raw.get(list_key)
+        if not isinstance(items, list) or not items:
+            continue
+        default_id = str(raw.get(default_key, "") or "").strip()
+        active_id = str(raw.get(active_key, "") or "").strip()
+        if not default_id or default_id == active_id:
+            continue
+        if not _find_item_by_id(items, default_id):
+            continue
+        raw[active_key] = default_id
+        changed = True
+        log(
+            "INFO",
+            "config_legacy_fix",
+            "reconciled stale selection pointer to default",
+            key=active_key,
+            value=default_id,
+            previous=active_id,
+        )
+    return changed
+
+
+_WARNED_UNKNOWN_SCHOOLS = set()
+
+
+def _sanitize_school(cfg):
+    """未知 school 值就地降级为内置默认，避免守护进程解析运行时时崩溃重启。
+
+    非破坏性：只改内存中的 cfg，不回写配置文件——若 schools/<name>.py 是稍后
+    才热部署的，下次 load_config 会自动识别并恢复。同一坏值每进程只告警一次，
+    防止每个 tick 刷日志。schools 模块不可用时直接放行，交给守护进程侧
+    resolve_runtime_safe 兜底。
+    """
+    name = str(cfg.get("school", "")).strip()
+    if not name or name == "default":
+        return
+    try:
+        import schools
+
+        known = schools.get_school_entry(name) is not None
+    except Exception:
+        return
+    if known:
+        return
+    if name not in _WARNED_UNKNOWN_SCHOOLS:
+        _WARNED_UNKNOWN_SCHOOLS.add(name)
+        log(
+            "WARN",
+            "config_legacy_fix",
+            "unknown school in config, using built-in default",
+            school=name,
+        )
+    cfg["school"] = "default"
+
+
 def load_config():
     raw = load_json_raw_config()
 
@@ -1027,6 +1165,12 @@ def load_config():
         try:
             save_json_raw_config(raw)
             log("INFO", "config_migrated", "legacy config migrated to new format")
+        except OSError:
+            pass
+
+    if _reconcile_selection_pointers(raw):
+        try:
+            save_json_raw_config(raw)
         except OSError:
             pass
 
@@ -1062,6 +1206,8 @@ def load_config():
 
     resolve_active_items(cfg)
 
+    _sanitize_school(cfg)
+
     cfg["backoff_max_retries"] = parse_non_negative_int(cfg["backoff_max_retries"], 0)
     cfg["backoff_initial_duration"] = parse_non_negative_float(
         cfg["backoff_initial_duration"], 10.0
@@ -1076,7 +1222,7 @@ def load_config():
         cfg["retry_max_cooldown_seconds"], 600.0
     )
     cfg["switch_ready_timeout_seconds"] = parse_non_negative_int(
-        cfg["switch_ready_timeout_seconds"], 12
+        cfg["switch_ready_timeout_seconds"], 30
     )
     cfg["manual_terminal_check_interval_seconds"] = parse_non_negative_int(
         cfg["manual_terminal_check_interval_seconds"], 2
@@ -1220,8 +1366,8 @@ def get_retry_max_cooldown_seconds(cfg):
 
 
 def get_switch_ready_timeout_seconds(cfg):
-    value = int(cfg.get("switch_ready_timeout_seconds", 12))
-    return value if value > 0 else 12
+    value = int(cfg.get("switch_ready_timeout_seconds", 30))
+    return value if value > 0 else 30
 
 
 def get_manual_terminal_check_interval_seconds(cfg):

--- a/root/usr/lib/smart_srun/daemon.py
+++ b/root/usr/lib/smart_srun/daemon.py
@@ -17,16 +17,20 @@ from config import (
     build_school_runtime_luci_contract,
     log,
     campus_uses_wired,
+    clear_inflight_action,
     clear_log_context,
     ensure_parent_dir,
     failover_enabled,
     in_quiet_window,
     load_config,
+    load_inflight_action,
     load_json_file,
     load_json_raw_config,
     load_runtime_state,
     localize_error,
+    mark_inflight_action,
     pop_runtime_action,
+    requeue_runtime_action,
     save_runtime_status,
     reconcile_manual_login_service_guard,
     set_log_context,
@@ -80,30 +84,82 @@ def load_pending_runtime_action():
     return payload if isinstance(payload, dict) else {}
 
 
+def _recover_interrupted_action():
+    """守护进程启动时恢复上次被中断的动作。
+
+    handle_runtime_action 出队后会写 inflight 标记、结束后清除。启动时若标记仍在，
+    说明上一个实例在执行途中被终止（常见于手动动作触发的 service restart 叠加）。
+    此时把动作重新排队一次（requeue_count 防止无限循环）；若用户已排入新动作，
+    则放弃旧动作，尊重最新意图。
+    """
+    inflight = load_inflight_action()
+    clear_inflight_action()
+    action = str(inflight.get("action") or "").strip()
+    if not action:
+        return
+    queued = load_pending_runtime_action()
+    if str(queued.get("action") or "").strip():
+        log(
+            "INFO",
+            "action_interrupted",
+            "interrupted action superseded by newer queued action",
+            action=action,
+        )
+        return
+    if int(inflight.get("requeue_count") or 0) >= 1:
+        log(
+            "WARN",
+            "action_interrupted",
+            "action interrupted again after requeue, giving up",
+            action=action,
+        )
+        return
+    inflight["requeue_count"] = 1
+    requeue_runtime_action(inflight)
+
+
 def _build_startup_status_payload():
     runtime_state = load_runtime_state()
     queued_action = load_pending_runtime_action()
 
-    pending_action = str(
-        queued_action.get("action") or runtime_state.get("pending_action") or ""
-    ).strip()
-    action_result = str(runtime_state.get("action_result") or "").strip()
-    requested_at = int(
-        queued_action.get("requested_at")
-        or runtime_state.get("action_started_at")
-        or runtime_state.get("last_action_ts")
-        or 0
-    )
-
-    if pending_action and (queued_action.get("action") or action_result == "pending"):
+    queued_name = str(queued_action.get("action") or "").strip()
+    if queued_name:
+        requested_at = int(
+            queued_action.get("requested_at")
+            or runtime_state.get("action_started_at")
+            or runtime_state.get("last_action_ts")
+            or 0
+        )
         return (
-            str(runtime_state.get("message") or ("正在执行动作: %s" % pending_action)),
+            str(runtime_state.get("message") or ("正在执行动作: %s" % queued_name)),
             {
-                "last_action": str(runtime_state.get("last_action") or pending_action),
+                "last_action": str(runtime_state.get("last_action") or queued_name),
                 "last_action_ts": requested_at,
                 "action_result": "pending",
                 "action_started_at": requested_at,
-                "pending_action": pending_action,
+                "pending_action": queued_name,
+            },
+        )
+
+    stale_pending = str(runtime_state.get("pending_action") or "").strip()
+    stale_result = str(runtime_state.get("action_result") or "").strip()
+    if stale_pending and stale_result == "pending":
+        # 队列里已没有该动作（出队后进程被终止且未能重新排队）。
+        # 必须显式收敛为 error，否则界面会永远停留在“待执行”。
+        log(
+            "WARN",
+            "action_interrupted",
+            "stale pending action found at startup, marking as error",
+            action=stale_pending,
+        )
+        return (
+            "上次动作 %s 未执行完成（守护进程重启），请重试" % stale_pending,
+            {
+                "last_action": stale_pending,
+                "last_action_ts": int(runtime_state.get("last_action_ts") or 0),
+                "action_result": "error",
+                "action_started_at": 0,
+                "pending_action": "",
             },
         )
 
@@ -217,6 +273,7 @@ def handle_runtime_action(cfg, state, runtime=None, app_ctx=None):
     requested_at = int(payload.get("requested_at") or action_started_at)
     op_id = "act-%d" % requested_at
     set_log_context(op_id=op_id, action=action)
+    mark_inflight_action(payload)
     try:
         log(
             "INFO",
@@ -225,6 +282,8 @@ def handle_runtime_action(cfg, state, runtime=None, app_ctx=None):
             requested_at=requested_at,
             queue_lag_ms=max(0, (action_started_at - requested_at) * 1000),
         )
+        # 此处不刷新运行时快照：快照里的连通性探测可能阻塞数十秒，
+        # 会让刚出队的动作迟迟不执行（界面表现为“待执行”卡死）。
         save_runtime_status(
             "正在执行动作: %s" % action,
             state,
@@ -233,13 +292,16 @@ def handle_runtime_action(cfg, state, runtime=None, app_ctx=None):
             action_result="pending",
             pending_action=action,
             action_started_at=action_started_at,
-            **build_runtime_snapshot(cfg, state),
         )
 
-        with timed() as t:
-            ok, message = school_runtime.dispatch_runtime_action(
-                runtime, app_ctx, action, state
-            )
+        try:
+            with timed() as t:
+                ok, message = school_runtime.dispatch_runtime_action(
+                    runtime, app_ctx, action, state
+                )
+        except Exception as exc:
+            ok = False
+            message = "动作执行异常: " + localize_error(exc)
         action_result = "ok" if ok else "error"
         if message.startswith("忽略未知动作:"):
             action_result = "ignored"
@@ -258,6 +320,7 @@ def handle_runtime_action(cfg, state, runtime=None, app_ctx=None):
             ok=ok,
             duration_ms=t.ms,
         )
+        # 先写结果解锁界面，再单独刷新快照（快照可能较慢）。
         save_runtime_status(
             message,
             state,
@@ -266,10 +329,18 @@ def handle_runtime_action(cfg, state, runtime=None, app_ctx=None):
             action_result=action_result,
             action_started_at=0,
             pending_action="",
+        )
+        # 动作已进入终态，立刻清除执行中标记：后面的快照可能走网络阻塞数十秒，
+        # 若拖到 finally 才清，这段窗口内被杀+重启会把已完成动作重放一次。
+        clear_inflight_action()
+        save_runtime_status(
+            message,
+            state,
             **build_runtime_snapshot(cfg, state),
         )
         return True, message
     finally:
+        clear_inflight_action()
         clear_log_context("op_id", "action")
 
 
@@ -372,16 +443,34 @@ def _daemon_tick_active(cfg, state, interval):
         urls = srun_auth.build_urls(cfg)
         online_now = False
         status_message = ""
+        online_name = ""
         if cfg["username"]:
-            online_now, status_message = srun_auth.query_online_status(
+            online_now, online_name, status_message = srun_auth.query_online_identity(
                 srun_profile, urls["rad_user_info_api"], cfg["username"]
             )
 
         if online_now:
+            expected_main = str(cfg["username"]).split("@", 1)[0]
+            if online_name and expected_main and online_name != expected_main:
+                # 别的账号占着本机会话（例如残留的第三方登录脚本、他人经
+                # 路由器网页认证）。srun 对已在线 IP 的重复登录会被拒绝，
+                # 强行抢登只会反复失败，这里只告警一次让用户能发现。
+                if state.get("online_mismatch_name") != online_name:
+                    state["online_mismatch_name"] = online_name
+                    log(
+                        "WARN",
+                        "online_account_mismatch",
+                        "online account differs from configured account",
+                        online=online_name,
+                        expected=expected_main,
+                    )
+            else:
+                state["online_mismatch_name"] = ""
             message = "在线，下一次检测间隔 %d 秒" % online_interval
             state["was_online"] = True
             next_sleep = online_interval
         else:
+            state["online_mismatch_name"] = ""
             if state["was_online"]:
                 log(
                     "WARN",
@@ -447,20 +536,30 @@ def _run_runtime_daemon_hook(app_ctx, state, interval):
     )
 
 
-def _acquire_daemon_lock():
+def _acquire_daemon_lock(max_wait_seconds=20):
     ensure_parent_dir(DAEMON_LOCK_FILE)
     lock_handle = open(DAEMON_LOCK_FILE, "a+", encoding="utf-8")
 
     try:
         import fcntl
-
-        fcntl.flock(lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except ImportError:
-        pass
-    except OSError:
-        lock_handle.close()
-        print("另一个 daemon 实例已在运行，退出。", flush=True)
-        raise SystemExit(1)
+        fcntl = None
+
+    if fcntl is not None:
+        # 手动动作会触发 service restart，procd 拉起新实例时旧实例可能还差
+        # 一两秒才退出。立刻放弃会白白烧掉 procd 的 respawn 预算（耗尽后守护
+        # 进程就再也起不来了），所以先等一小段时间让旧实例退出。
+        deadline = time.time() + max(int(max_wait_seconds), 0)
+        while True:
+            try:
+                fcntl.flock(lock_handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.time() >= deadline:
+                    lock_handle.close()
+                    print("另一个 daemon 实例已在运行，退出。", flush=True)
+                    raise SystemExit(1)
+                time.sleep(0.5)
 
     lock_handle.seek(0)
     lock_handle.truncate()
@@ -472,9 +571,10 @@ def _acquire_daemon_lock():
 def run_daemon(runtime=None):
     _daemon_lock = _acquire_daemon_lock()
     reconcile_manual_login_service_guard()
+    _recover_interrupted_action()
     state = _make_daemon_state()
     startup_cfg = load_config()
-    runtime = runtime or school_runtime.resolve_runtime(startup_cfg)
+    runtime = runtime or school_runtime.resolve_runtime_safe(startup_cfg)
     startup_message, startup_action_state = _build_startup_status_payload()
     log(
         "INFO",
@@ -487,23 +587,22 @@ def run_daemon(runtime=None):
         failover=startup_cfg.get("failover_enabled", "0"),
         log_level=startup_cfg.get("log_level", "INFO"),
     )
+    # 启动时不做运行时快照：快照内的连通性探测可能阻塞几十秒，会推迟
+    # 首个排队动作的执行。快照字段沿用 state.json 里的上次值，首个 tick 会刷新。
     save_runtime_status(
         startup_message,
         state,
         daemon_running=True,
         enabled=True,
         **startup_action_state,
-        **build_runtime_snapshot(startup_cfg, state),
     )
 
     tick_counter = 0
     while True:
         cfg = load_config()
         runtime_state = load_runtime_state()
-        _refresh_school_presets_after_online(runtime_state)
-        state["presets_refresh_checked_at"] = runtime_state.get("presets_refresh_checked_at", 0)
         interval = max(int(cfg["interval"]), 5)
-        runtime = school_runtime.resolve_runtime(cfg)
+        runtime = school_runtime.resolve_runtime_safe(cfg)
         app_ctx = school_runtime.build_app_context(cfg, runtime=runtime)
 
         tick_counter += 1
@@ -516,12 +615,17 @@ def run_daemon(runtime=None):
             was_online=state.get("was_online", False),
         )
 
+        # 动作消费必须是 tick 的第一步：presets 刷新等可能走网络的步骤
+        # 一旦阻塞，排队中的手动动作会被 LuCI 判定为滞留而丢弃。
         action_handled, action_message = handle_runtime_action(
             cfg, state, runtime=runtime, app_ctx=app_ctx
         )
         if action_handled:
             time.sleep(1)
             continue
+
+        _refresh_school_presets_after_online(runtime_state)
+        state["presets_refresh_checked_at"] = runtime_state.get("presets_refresh_checked_at", 0)
 
         if cfg["enabled"] != "1":
             state.update(_make_daemon_state())
@@ -740,27 +844,27 @@ def _runtime_cli_login(app_ctx):
             "夜间停用中（北京时间 %s），不执行登录" % quiet_window_label(cfg),
         )
     if not cfg["username"] or not cfg["password"]:
-        return True, 0, "请先配置学工号和密码: srunnet config account add"
+        return True, 1, "请先配置学工号和密码: srunnet config account add"
     ok_prep, msg_prep = orchestrator.prepare_campus_for_login(cfg)
     if not ok_prep:
-        return True, 0, msg_prep
+        return True, 1, msg_prep
     ok, message = runtime.login_once(app_ctx)
     log("INFO", "action_result", "login: " + message, action="login")
-    return True, 0, message
+    return True, 0 if ok else 1, message
 
 
 def _runtime_cli_logout(app_ctx):
     cfg = app_ctx["cfg"]
     ok, message = orchestrator.run_manual_logout(cfg)
     log("INFO", "action_result", "logout: " + message, action="logout")
-    return True, 0, message
+    return True, 0 if ok else 1, message
 
 
 def _runtime_cli_relogin(app_ctx):
     cfg = app_ctx["cfg"]
     ok, message = orchestrator.run_manual_login(cfg)
     log("INFO", "action_result", "relogin: " + message, action="relogin")
-    return True, 0, message
+    return True, 0 if ok else 1, message
 
 
 def _emit_cli_result(result):
@@ -954,6 +1058,20 @@ def _config_set(pairs, json_file=None):
             print("未知配置项: %s" % key)
             print("可用: %s" % ", ".join(sorted(GLOBAL_SCALAR_KEYS)))
             return
+        if key == "school":
+            candidate = str(val).strip()
+            if candidate and candidate != "default":
+                import schools
+
+                if not schools.get_school_entry(candidate):
+                    names = [
+                        str(m.get("short_name") or m.get("id") or "")
+                        for m in schools.list_schools()
+                    ]
+                    names = [n for n in names if n]
+                    print("未知学校运行时: %s（注意这是 schools/ 下的运行时短名，不是预设 id）" % candidate)
+                    print("可用: default%s" % (", " + ", ".join(names) if names else ""))
+                    return
         old = raw.get(key, "")
         changed.append((key, old, val))
 

--- a/root/usr/lib/smart_srun/defaults.json
+++ b/root/usr/lib/smart_srun/defaults.json
@@ -11,7 +11,7 @@
   "backoff_max_duration": "600",
   "retry_cooldown_seconds": "10",
   "retry_max_cooldown_seconds": "600",
-  "switch_ready_timeout_seconds": "12",
+  "switch_ready_timeout_seconds": "30",
   "manual_terminal_check_max_attempts": "5",
   "manual_terminal_check_interval_seconds": "2",
   "hotspot_failback_enabled": "1",

--- a/root/usr/lib/smart_srun/network.py
+++ b/root/usr/lib/smart_srun/network.py
@@ -45,20 +45,42 @@ CONNECTIVITY_CHECK_URLS = [
 ]
 
 
-def run_cmd(cmd):
+def run_cmd(cmd, timeout=60):
     try:
         res = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
         )
         return res.returncode == 0, (res.stdout or res.stderr or "").strip()
+    except subprocess.TimeoutExpired:
+        return False, "命令超时（%ds）: %s" % (timeout, " ".join(str(c) for c in cmd))
     except OSError as exc:
         return False, str(exc)
+
+
+def _wget_supports_bind(path):
+    """真实的 GNU wget 才支持 --bind-address；uclient-fetch / busybox 不支持。"""
+    try:
+        real = os.path.realpath(path)
+    except OSError:
+        real = path
+    base = os.path.basename(real).lower()
+    return "uclient" not in base and "busybox" not in base
 
 
 def parse_uci_value(raw):
     text = str(raw or "").strip()
     if len(text) >= 2 and text[0] == text[-1] and text[0] in ('"', "'"):
-        return text[1:-1]
+        inner = text[1:-1]
+        if text[0] == "'":
+            # uci 把值内单引号输出为 '\''（关引号+转义引号+开引号），此处还原，
+            # 否则含撇号的 SSID/密码读回值与写入值不符，会触发每 30s 重建循环、
+            # 手动登录校验永远失败。
+            inner = inner.replace("'\\''", "'")
+        return inner
     return text
 
 
@@ -368,11 +390,14 @@ def http_get(url, params=None, timeout=5, bind_ip=None):
             if not os.path.exists(path):
                 continue
             available = True
-            if kind == "wget":
+            # 原生 OpenWrt 的 /usr/bin/wget 往往是 uclient-fetch 的符号链接，
+            # 不认识 --bind-address；按真实实现判断，避免给它传该参数直接报错退出。
+            supports_bind = kind == "wget" and _wget_supports_bind(path)
+            if supports_bind:
                 bind_capable = True
 
-            if bind_ip and kind != "wget":
-                errors.append("%s: bind_ip requires wget --bind-address support" % kind)
+            if bind_ip and not supports_bind:
+                errors.append("%s: 不支持 --bind-address（uclient-fetch/busybox）" % kind)
                 continue
 
             if kind == "wget":
@@ -383,8 +408,14 @@ def http_get(url, params=None, timeout=5, bind_ip=None):
             else:
                 cmd = [path, "-q", "-O", "-", "--timeout", str(int(timeout)), url]
 
+            # GNU wget 的 --timeout 只约束单次尝试，默认还会重试 20 次并线性
+            # 退避，实测单个探测可拖到 4 分钟以上，把守护循环整个卡住。
+            # 用子进程级硬超时兜底，对 busybox/GNU 两种实现都成立。
+            hard_cap = max(int(timeout) * 2, int(timeout) + 3)
             try:
-                output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                output = subprocess.check_output(
+                    cmd, stderr=subprocess.STDOUT, timeout=hard_cap
+                )
                 body = output.decode("utf-8", errors="replace")
                 log(
                     "DEBUG",
@@ -396,6 +427,8 @@ def http_get(url, params=None, timeout=5, bind_ip=None):
                     duration_ms=t.ms,
                 )
                 return body
+            except subprocess.TimeoutExpired:
+                errors.append("%s: timed out after %ds (hard cap)" % (kind, hard_cap))
             except subprocess.CalledProcessError as exc:
                 details = exc.output.decode("utf-8", errors="replace") if exc.output else ""
                 if not details:

--- a/root/usr/lib/smart_srun/school_presets.py
+++ b/root/usr/lib/smart_srun/school_presets.py
@@ -237,7 +237,13 @@ def normalize_school(item):
 def normalize_payload(payload, include_draft=False):
     if not isinstance(payload, dict):
         return []
-    if int(payload.get("schema_version") or 0) != SCHEMA_VERSION:
+    try:
+        schema_version = int(payload.get("schema_version") or 0)
+    except (TypeError, ValueError):
+        # 远端把 schema_version 写成 "abc"/"v2"/数组等非法值时，视为版本不匹配，
+        # 而不是让 int() 抛异常把整个预设加载（含内置 fallback）打崩。
+        return []
+    if schema_version != SCHEMA_VERSION:
         return []
     out = []
     seen = set()
@@ -328,8 +334,21 @@ def _payload_updated_at(payload):
     return str(payload.get("updated_at") or "").strip()
 
 
+def _payload_schema_ok(payload):
+    if not isinstance(payload, dict):
+        return False
+    try:
+        return int(payload.get("schema_version") or 0) == SCHEMA_VERSION
+    except (TypeError, ValueError):
+        return False
+
+
 def refresh_remote_presets(url=None, timeout=REMOTE_TIMEOUT_SECONDS):
     payload, source_url = _fetch_remote_payload_with_source(url=url, timeout=timeout)
+    # 先校验再落盘：非法 schema_version 的远端发布不写入缓存，否则会毒化本地
+    # 缓存，此后每次 list_presets 都从坏缓存崩溃且无法自愈（连内置 fallback 一起丢）。
+    if not _payload_schema_ok(payload):
+        raise RuntimeError("远端预设 schema_version 非法，已拒绝缓存")
     cached = _read_json(CACHE_PRESETS_FILE)
     remote_version = _payload_updated_at(payload)
     cached_version = _payload_updated_at(cached)
@@ -358,6 +377,8 @@ def _refresh_remote_payload_for_list():
             timeout=REMOTE_TIMEOUT_SECONDS
         )
     except Exception:
+        return {}
+    if not _payload_schema_ok(payload):
         return {}
     payload["_cached_at"] = int(time.time())
     payload["_source_url"] = source_url

--- a/root/usr/lib/smart_srun/school_presets_fallback.json
+++ b/root/usr/lib/smart_srun/school_presets_fallback.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-06-26",
+  "updated_at": "2026-07-19",
   "source": "bundled fallback",
   "schools": [
     {
@@ -8,6 +8,7 @@
       "name": "江西师范大学",
       "status": "active",
       "description": "江西师范大学预设。",
+      "doc_url": "https://github.com/matthewlu070111/smart-srun/blob/main/doc/jxnu.md",
       "defaults": {
         "base_url": "http://172.17.1.2",
         "ac_id": "1",
@@ -173,6 +174,41 @@
         "@zhaogods"
       ],
       "source_issue": "https://github.com/matthewlu070111/smart-srun/issues/20"
+    },
+    {
+      "id": "nchu",
+      "name": "南昌航空大学（前湖校区）",
+      "status": "active",
+      "description": "环境信息来自 #22 真实抓包；电信运营商后缀尚未验证（捕获脚本上报值与实际不符），选择后请按提示手动确认。",
+      "defaults": {
+        "base_url": "http://10.1.88.4",
+        "ac_id": "1",
+        "ssid": "NCHU_Wireless",
+        "access_mode": "wifi"
+      },
+      "observed_login_shape": {
+        "n": "200",
+        "type": "1",
+        "enc": "srun_bx1",
+        "info_prefix": "SRBX1",
+        "double_stack": "0",
+        "os": "Mac OS",
+        "name": "Macintosh"
+      },
+      "operators": [
+        {
+          "suffix": "??",
+          "label": "中国电信"
+        },
+        {
+          "suffix": "",
+          "label": "校园网"
+        }
+      ],
+      "contributors": [
+        "@REALBochengWen"
+      ],
+      "source_issue": "https://github.com/matthewlu070111/smart-srun/issues/22"
     },
     {
       "id": "hsyu",

--- a/root/usr/lib/smart_srun/school_runtime.py
+++ b/root/usr/lib/smart_srun/school_runtime.py
@@ -270,6 +270,29 @@ def resolve_runtime(cfg):
     raise LookupError("school runtime has no supported entrypoint: %s" % short_name)
 
 
+def resolve_runtime_safe(cfg):
+    """像 resolve_runtime，但把无法解析的学校降级为内置默认运行时而非抛异常。
+
+    守护进程主循环必须用它：若 config 里的 school 值未知（例如把预设 id 误当
+    school 值填入、或 schools/ 模块缺失/损坏），裸 resolve_runtime 抛 LookupError
+    会让守护进程启动即退出，procd 无限重生 → 认证完全停摆、syslog 刷屏。
+    与 CLAUDE.md 解析链“-> built-in default”一致。
+    """
+    try:
+        return resolve_runtime(cfg)
+    except LookupError as exc:
+        log(
+            "WARN",
+            "runtime_resolved",
+            "unknown school runtime, falling back to built-in default",
+            school=str((cfg or {}).get("school", "")),
+            reason=str(exc),
+            runtime_type="DefaultRuntime",
+            source="fallback",
+        )
+        return DefaultRuntime()
+
+
 def build_app_context(cfg, runtime=None):
     cfg = cfg or {}
     runtime = runtime or resolve_runtime(cfg)

--- a/root/usr/lib/smart_srun/updater.py
+++ b/root/usr/lib/smart_srun/updater.py
@@ -143,8 +143,29 @@ def _version_tuple(value):
     return tuple(nums or [0])
 
 
+def _version_sort_key(value):
+    """把版本串解析为可比较的 key，正确处理预发布语义。
+
+    预发布（-bN / -betaN / -rcN / _betaN 等，含字母标记）排在同号正式版之前，
+    因此同一主版本下 “无预发布 > 有预发布”。修复 beta 用户永远收不到同号
+    正式版更新的问题（旧实现把 -b2 的 2 当成第 4 段版本号，反而判成更高）。
+    """
+    text = _release_version(str(value or "").strip())
+    text = text.split("-r", 1)[0]
+    match = re.match(r"^(\d+(?:\.\d+)*)(.*)$", text)
+    if not match:
+        return ((0,), 1, ())
+    release = tuple(int(p) for p in match.group(1).split("."))
+    rest = match.group(2)
+    is_prerelease = bool(re.search(r"[A-Za-z]", rest))
+    if is_prerelease:
+        pre_nums = tuple(int(n) for n in re.findall(r"\d+", rest)) or (0,)
+        return (release, 0, pre_nums)
+    return (release, 1, ())
+
+
 def is_remote_newer(current_version, latest_tag):
-    return _version_tuple(latest_tag) > _version_tuple(current_version)
+    return _version_sort_key(latest_tag) > _version_sort_key(current_version)
 
 
 def _fetch_json(url, timeout=12):
@@ -609,8 +630,13 @@ def run_update():
 
 def start_background_update():
     status = get_status()
-    if status.get("running"):
+    holder = _read_lock_pid()
+    if status.get("running") and holder and _pid_alive(holder):
         return dict(status, ok=False, message="已有更新任务正在运行")
+    if status.get("running"):
+        # 状态残留 running 但持有进程已死（被 kill/OOM/服务重启杀掉）：视为陈旧，
+        # 清理后继续；否则 LuCI「立即更新」会被永久挡住，只能重启路由器恢复。
+        _append_log("clearing stale running status (holder pid=%s)" % (holder or "?"))
     _set_status("queued", "已提交后台更新任务", ok=True, running=True)
     cmd = [
         sys.executable or "python3",

--- a/root/usr/lib/smart_srun/wireless.py
+++ b/root/usr/lib/smart_srun/wireless.py
@@ -911,6 +911,11 @@ def wait_for_sta_ipv4(
     deadline = started_at + max(int(timeout_seconds), 1)
     last_net = get_network_interface_from_sta_section(sec)
     last_progress_log = 0.0
+    # 等到一半（至少 5 秒）仍无 IPv4 时主动 ifup 一次承载接口：部分环境
+    #（如南昌航空 issue #22）关联成功但 DHCP 迟迟不来，被动轮询会一直等到
+    # 超时；ifup 对已 up 的接口安全，可触发 netifd 重新发起 DHCP。
+    kick_at = started_at + min(max(int(timeout_seconds) // 2, 5), int(timeout_seconds))
+    kicked = False
 
     while time.time() < deadline:
         net = get_network_interface_from_sta_section(sec)
@@ -931,6 +936,19 @@ def wait_for_sta_ipv4(
                 )
                 return net, ip
         now = time.time()
+        if (not kicked) and now >= kick_at:
+            kicked = True
+            kick_net = net or last_net
+            if kick_net:
+                log(
+                    "INFO",
+                    "dhcp_kick",
+                    "no IPv4 yet, re-triggering DHCP via ifup",
+                    section=sec,
+                    network=kick_net,
+                    elapsed_ms=int((now - started_at) * 1000),
+                )
+                bring_up_network_interface(kick_net)
         if now - last_progress_log >= 2.0:
             last_progress_log = now
             log(
@@ -1078,10 +1096,14 @@ def switch_sta_profile(cfg, expect_hotspot):
             radio=radio or "?",
             band=bl,
         )
-        return False, "已切换为%s配置但未获取到IPv4地址（%s %s）" % (
-            target["label"],
-            radio or "?",
-            bl,
+        return False, (
+            "已切换为%s配置但未获取到IPv4地址（%s %s）；"
+            "可在全局设置调大“切网就绪等待”，并确认该账号是否已有其他设备在线占用名额"
+            % (
+                target["label"],
+                radio or "?",
+                bl,
+            )
         )
 
     _, ip = wait_for_sta_ipv4(section, timeout_seconds=ip_timeout)

--- a/root/www/luci-static/resources/smart_srun.js
+++ b/root/www/luci-static/resources/smart_srun.js
@@ -434,6 +434,7 @@
     return items && items.length ? items : [{
       short_name: 'jxnu',
       name: '江西师范大学',
+      doc_url: 'https://github.com/matthewlu070111/smart-srun/blob/main/doc/jxnu.md',
       defaults: { base_url: 'http://172.17.1.2', ac_id: '1', ssid: 'jxnu_stu' },
       observed_login_shape: { n: '200', type: '1', enc: 'srun_bx1', info_prefix: 'SRBX1', double_stack: '0', os: 'Windows 10', name: 'Windows' },
       operators: [
@@ -490,17 +491,16 @@
     var xhr = new XMLHttpRequest();
     xhr.open('POST', '/cgi-bin/luci/admin/services/smart_srun/enqueue', true);
     xhr.onload = function() {
-      var message = '已保存默认配置';
-      if (xhr.status === 200) {
-        try {
-          var data = JSON.parse(xhr.responseText || '{}');
-          if (typeof data.message === 'string' && data.message !== '')
-            message = data.message;
-        } catch (e) {}
+      var data = {};
+      try { data = JSON.parse(xhr.responseText || '{}'); } catch (e) {}
+      if (xhr.status === 200 && data.ok !== false) {
+        alert((typeof data.message === 'string' && data.message !== '') ? data.message : '已保存默认配置');
+        location.reload();
+      } else {
+        alert((data && data.message) ? data.message : ('操作失败（HTTP ' + xhr.status + '）'));
       }
-      alert(message);
-      location.reload();
     };
+    xhr.onerror = function() { alert('操作失败：网络错误，请重试'); };
     xhr.send(fd);
   };
 
@@ -511,7 +511,16 @@
     fd.append('id', id);
     var xhr = new XMLHttpRequest();
     xhr.open('POST', '/cgi-bin/luci/admin/services/smart_srun/enqueue', true);
-    xhr.onload = function() { location.reload(); };
+    xhr.onload = function() {
+      var data = {};
+      try { data = JSON.parse(xhr.responseText || '{}'); } catch (e) {}
+      if (xhr.status === 200 && data.ok !== false) {
+        location.reload();
+      } else {
+        alert((data && data.message) ? data.message : ('删除失败（HTTP ' + xhr.status + '）'));
+      }
+    };
+    xhr.onerror = function() { alert('删除失败：网络错误，请重试'); };
     xhr.send(fd);
   };
 
@@ -629,7 +638,7 @@
       '<div class="smart-native-row"><label>学校预设</label><span><select id="jm-school_preset">' + presetOptionsMarkup() + '</select> <button type="button" id="jm-apply-school-defaults" class="btn cbi-button cbi-button-action">应用预设</button> <button type="button" id="jm-reset-school-defaults" class="btn cbi-button">复位</button></span></div>' +
       '<div class="smart-native-row"><label>标签（选填）</label><input id="jm-label" value="' + escapeHtml(initialValues.label) + '"></div>' +
       '<div class="smart-native-row"><label>学工号</label><input id="jm-user_id" value="' + escapeHtml(initialValues.user_id) + '"></div>' +
-      '<div class="smart-native-row"><label>运营商后缀 <a href="https://github.com/matthewlu070111/smart-srun#%E8%8E%B7%E5%8F%96%E5%AD%A6%E9%A2%84%E8%AE%BE%E4%B8%8E%E8%BF%90%E8%90%A5%E5%95%86%E5%90%8E%E7%BC%80" target="_blank" rel="noopener noreferrer">如何获取？</a></label>' +
+      '<div class="smart-native-row"><label>运营商后缀 <a href="https://github.com/matthewlu070111/smart-srun#%E8%8E%B7%E5%8F%96%E5%AD%A6%E6%A0%A1%E9%A2%84%E8%AE%BE%E4%B8%8E%E7%8E%AF%E5%A2%83%E7%9C%9F%E5%AE%9E%E5%AD%97%E6%AE%B5%E5%80%BC" target="_blank" rel="noopener noreferrer">如何获取？</a></label>' +
         '<span id="jm-operator-quickpick-wrap" style="display:' + quickpickDisplay + ';margin-bottom:.35rem;"><select id="jm-operator">' + operatorOptionsMarkup(initialOperators, initialValues.operator_suffix) + '</select></span>' +
         '<input id="jm-operator_suffix" value="' + escapeHtml(initialValues.operator_suffix) + '" placeholder="">' +
         '<div id="jm-operator-suffix-hint" style="display:none;color:#d97706;font-size:12px;margin-top:.25rem;"></div></div>' +
@@ -830,6 +839,8 @@
   };
 
   window.smartModalSave = function() {
+    if (window.__smartModalSaving) return;
+    window.__smartModalSaving = true;
     var fd = new FormData();
     fd.append('action', (modalEditId ? 'edit_' : 'add_') + modalType);
     if (modalEditId) fd.append('id', modalEditId);
@@ -863,8 +874,20 @@
     var xhr = new XMLHttpRequest();
     xhr.open('POST', '/cgi-bin/luci/admin/services/smart_srun/enqueue', true);
     xhr.onload = function() {
-      L.hideModal();
-      location.reload();
+      var data = {};
+      try { data = JSON.parse(xhr.responseText || '{}'); } catch (e) {}
+      if (xhr.status === 200 && data.ok !== false) {
+        L.hideModal();
+        location.reload();
+      } else {
+        // 失败时保持弹窗打开，避免静默丢弃用户刚填的整套表单。
+        window.__smartModalSaving = false;
+        alert((data && data.message) ? data.message : ('保存失败（HTTP ' + xhr.status + '）'));
+      }
+    };
+    xhr.onerror = function() {
+      window.__smartModalSaving = false;
+      alert('保存失败：网络错误，请重试');
     };
     xhr.send(fd);
   };
@@ -875,7 +898,14 @@
     if (!infoBox || !docLinkEl || window.__smartSchoolInfoInit) return;
     window.__smartSchoolInfoInit = true;
 
-    var DOC_BASE = 'https://github.com/matthewlu070111/smart-srun/blob/main/doc/';
+    var DOC_FALLBACK = 'https://github.com/matthewlu070111/smart-srun/tree/main/doc';
+    function docUrlFor(value) {
+      var items = schoolPresetList();
+      for (var i = 0; i < items.length; i++) {
+        if (items[i] && items[i].short_name === value && items[i].doc_url) return items[i].doc_url;
+      }
+      return DOC_FALLBACK;
+    }
     var outerDescEl = null;
     for (var parent = infoBox.parentNode; parent; parent = parent.parentNode) {
       if (parent.className && String(parent.className).indexOf('cbi-value-description') >= 0) {
@@ -905,7 +935,7 @@
     function update(value) {
       infoBox.style.display = 'block';
       if (outerDescEl) outerDescEl.style.display = 'block';
-      docLinkEl.href = DOC_BASE + encodeURIComponent(String(value || '')) + '.md';
+      docLinkEl.href = docUrlFor(String(value || ''));
     }
 
     update(sel.value);

--- a/tests/test_release_assets.py
+++ b/tests/test_release_assets.py
@@ -724,12 +724,20 @@ class ReleaseAssetsUnifiedTests(unittest.TestCase):
                 encoding="utf-8"
             )
             self.assertIn('if [ "${{ matrix.format }}" = "apk" ]; then', workflow)
-            self.assertIn('VERSION="${VERSION//-/_}"', workflow)
             self.assertIn("uses: actions/checkout@v7", workflow)
             self.assertIn("uses: actions/cache@v6", workflow)
             self.assertIn("uses: actions/upload-artifact@v7", workflow)
             self.assertIn("uses: actions/download-artifact@v8", workflow)
             self.assertIn("uses: softprops/action-gh-release@v3", workflow)
+        prerelease = (
+            root / ".github" / "workflows" / "build-prerelease.yml"
+        ).read_text(encoding="utf-8")
+        # apk-tools 只接受 _alpha/_beta/_pre/_rc 后缀；预发布 apk 版本必须用合法的
+        # _beta<N>，而不是曾导致 mkpkg "package version is invalid" 的 _b<N>。
+        self.assertIn(
+            'VERSION="${BASE_VERSION}_beta${{ github.event.inputs.beta }}"', prerelease
+        )
+        self.assertNotIn('VERSION="${VERSION//-/_}"', prerelease)
 
     def test_unified_prepare_zip_contains_all_four_split_packages(self):
         release_assets = load_release_assets_module(self)

--- a/tests/test_school_runtime_cli.py
+++ b/tests/test_school_runtime_cli.py
@@ -769,6 +769,8 @@ class SchoolRuntimeCliTests(unittest.TestCase):
             ),
             mock.patch.object(daemon, "save_runtime_status"),
             mock.patch.object(daemon, "build_runtime_snapshot", return_value={}),
+            mock.patch.object(daemon, "mark_inflight_action"),
+            mock.patch.object(daemon, "clear_inflight_action"),
         ):
             self.runtime.handle_runtime_action = mock.Mock(
                 return_value=(True, "bad", "shape")
@@ -791,6 +793,8 @@ class SchoolRuntimeCliTests(unittest.TestCase):
             ),
             mock.patch.object(daemon, "save_runtime_status"),
             mock.patch.object(daemon, "build_runtime_snapshot", return_value={}),
+            mock.patch.object(daemon, "mark_inflight_action"),
+            mock.patch.object(daemon, "clear_inflight_action"),
         ):
             self.runtime.handle_runtime_action = mock.Mock(
                 side_effect=RuntimeError("boom")

--- a/tests/test_school_runtime_cli.py
+++ b/tests/test_school_runtime_cli.py
@@ -2,6 +2,7 @@ import io
 import importlib.util
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -12,6 +13,14 @@ from unittest import mock
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODULE_ROOT = os.path.join(REPO_ROOT, "root", "usr", "lib", "smart_srun")
+
+# Python 3.14 起 argparse 会给帮助输出着色，断言前需剥离 ANSI 转义序列。
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text):
+    return _ANSI_ESCAPE_RE.sub("", text)
+
 
 if MODULE_ROOT not in sys.path:
     sys.path.insert(0, MODULE_ROOT)
@@ -276,7 +285,7 @@ class SchoolRuntimeCliTests(unittest.TestCase):
         ):
             daemon.main()
 
-        text = stdout.getvalue()
+        text = strip_ansi(stdout.getvalue())
         self.assertIn("usage: srunnet", text)
         self.assertIn("常用命令组", text)
 
@@ -289,7 +298,7 @@ class SchoolRuntimeCliTests(unittest.TestCase):
         ):
             daemon.main()
 
-        text = stdout.getvalue()
+        text = strip_ansi(stdout.getvalue())
         self.assertIn("usage: srunnet config", text)
         self.assertIn("show", text)
 
@@ -302,7 +311,7 @@ class SchoolRuntimeCliTests(unittest.TestCase):
         ):
             daemon.main()
 
-        text = stdout.getvalue()
+        text = strip_ansi(stdout.getvalue())
         self.assertIn("usage: srunnet config account", text)
 
     def test_help_with_unknown_command_returns_nonzero_and_writes_to_stderr(self):
@@ -750,7 +759,7 @@ class SchoolRuntimeCliTests(unittest.TestCase):
                 daemon.main()
 
         self.assertEqual(exc.exception.code, 0)
-        self.assertIn("usage: srunnet", stdout.getvalue())
+        self.assertIn("usage: srunnet", strip_ansi(stdout.getvalue()))
 
     def test_runtime_action_contract_error_is_isolated(self):
         state = {"current_mode": "campus", "last_switch_ts": 0}


### PR DESCRIPTION
PR #23 合并后 CI 失败:`test_runtime_action_contract_error_is_isolated` 和 `test_runtime_action_exception_is_isolated` 在 CI 的非特权环境下真实调用了 `mark_inflight_action`,尝试创建 `/var/run/smart_srun` 触发 PermissionError(本地 Windows 上 `/var/run` 落在盘符根目录下所以侥幸通过)。

修复:与这两个测试里其他 daemon 协作者一致,补上 `mark_inflight_action` / `clear_inflight_action` 的 mock。本地 205 项测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)