### PR TITLE
fix: fall back to wget when updater lacks idna codec

### DIFF
--- a/root/usr/lib/smart_srun/updater.py
+++ b/root/usr/lib/smart_srun/updater.py
@@ -173,17 +173,40 @@ def _fetch_json(url, timeout=12):
     return json.loads(text)
 
 
+def _stdlib_http_is_usable():
+    """OpenWrt python3-light often ships urllib but lacks the idna codec.
+
+    Hostname resolution then raises LookupError('unknown encoding: idna')
+    before any network IO. Prefer detecting that early so we can fall back to
+    uclient-fetch/wget (which work fine on these devices).
+    """
+    if urlrequest is None:
+        return False
+    try:
+        "example.com".encode("idna")
+    except LookupError:
+        return False
+    return True
+
+
 def _fetch_text(url, timeout=12, accept="*/*"):
-    if urlrequest is not None:
-        req = urlrequest.Request(
-            url,
-            headers={
-                "Accept": accept,
-                "User-Agent": "smart-srun-updater/1",
-            },
-        )
-        with urlrequest.urlopen(req, timeout=timeout) as response:
-            return response.read().decode("utf-8", "replace")
+    if _stdlib_http_is_usable():
+        try:
+            req = urlrequest.Request(
+                url,
+                headers={
+                    "Accept": accept,
+                    "User-Agent": "smart-srun-updater/1",
+                },
+            )
+            with urlrequest.urlopen(req, timeout=timeout) as response:
+                return response.read().decode("utf-8", "replace")
+        except LookupError:
+            # idna / codec path can still fail late on some builds.
+            pass
+        except OSError:
+            # Fall through to system clients when stdlib networking is broken.
+            pass
     return _fetch_via_system_client(url, timeout).decode("utf-8", "replace")
 
 
@@ -193,7 +216,19 @@ def _fetch_via_system_client(url, timeout=30):
         binary = shutil.which(command)
         if not binary:
             continue
-        args = [binary, "-q", "-O", "-", url]
+        if command == "wget":
+            args = [
+                binary,
+                "-q",
+                "-O",
+                "-",
+                "--timeout=%s" % int(timeout),
+                "--user-agent=smart-srun-updater/1",
+                url,
+            ]
+        else:
+            # uclient-fetch has no portable UA flag across OpenWrt versions.
+            args = [binary, "-q", "-O", "-", url]
         try:
             return subprocess.check_output(
                 args, stderr=subprocess.STDOUT, timeout=timeout
@@ -204,10 +239,17 @@ def _fetch_via_system_client(url, timeout=30):
 
 
 def _fetch_binary(url, timeout=30):
-    if urlrequest is not None:
-        req = urlrequest.Request(url, headers={"User-Agent": "smart-srun-updater/1"})
-        with urlrequest.urlopen(req, timeout=timeout) as response:
-            return response.read()
+    if _stdlib_http_is_usable():
+        try:
+            req = urlrequest.Request(
+                url, headers={"User-Agent": "smart-srun-updater/1"}
+            )
+            with urlrequest.urlopen(req, timeout=timeout) as response:
+                return response.read()
+        except LookupError:
+            pass
+        except OSError:
+            pass
     return _fetch_via_system_client(url, timeout)
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -152,6 +152,45 @@ class SplitZipDigestTests(unittest.TestCase):
         self.assertEqual(updater._parse_sha256("not-a-hash file"), "")
 
 
+class UpdaterHttpFallbackTests(unittest.TestCase):
+    def test_fetch_text_falls_back_when_stdlib_lacks_idna_codec(self):
+        # OpenWrt python3-light: urllib exists but "example.com".encode("idna")
+        # raises LookupError; updater must use uclient-fetch/wget instead.
+        with (
+            mock.patch.object(updater, "_stdlib_http_is_usable", return_value=False),
+            mock.patch.object(
+                updater,
+                "_fetch_via_system_client",
+                return_value=b'{"tag_name":"v1.4.0"}',
+            ) as system_fetch,
+        ):
+            text = updater._fetch_text(
+                "https://api.github.com/repos/example/smart-srun/releases/latest"
+            )
+
+        self.assertEqual(text, '{"tag_name":"v1.4.0"}')
+        system_fetch.assert_called_once()
+
+    def test_fetch_text_falls_back_when_urlopen_raises_lookup_error(self):
+        with (
+            mock.patch.object(updater, "_stdlib_http_is_usable", return_value=True),
+            mock.patch.object(
+                updater.urlrequest,
+                "urlopen",
+                side_effect=LookupError("unknown encoding: idna"),
+            ),
+            mock.patch.object(
+                updater,
+                "_fetch_via_system_client",
+                return_value=b"ok-from-wget",
+            ) as system_fetch,
+        ):
+            text = updater._fetch_text("https://example.invalid/x")
+
+        self.assertEqual(text, "ok-from-wget")
+        system_fetch.assert_called_once()
+
+
 class UpdateFinishHandoffTests(unittest.TestCase):
     def test_write_finish_worker_uses_tmp_script_not_client_py(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- OpenWrt `python3-light` often has `urllib` but no `idna` codec, so `srunnet update check` fails with `unknown encoding: idna` even when GitHub is reachable via `uclient-fetch`/`wget`.
- Detect unusable stdlib HTTP early, fall back to system downloaders for text/binary fetches, and add regression tests.
- Reproduced on a production router at `1.3.4` against the published `v1.4.0` release; after the fix, check reports `update_available: true` for `v1.4.0`.

## Test plan
- [x] `python -m pytest tests/test_updater.py -v`
- [x] Router: before fix → `检查更新失败: unknown encoding: idna`
- [x] Router: after hot-deploy → `latest_tag: v1.4.0`, `update_available: true`
- [ ] CI green on this PR