### PR TITLE
fix: replace school preset operators instead of merging

### DIFF
--- a/root/www/luci-static/resources/smart_srun.js
+++ b/root/www/luci-static/resources/smart_srun.js
@@ -660,11 +660,18 @@
       }
     }
 
-    // 应用预设时把该预设的 operators 合并进下拉（预填写，不覆盖已有条目）。
-    function mergePresetOperators(preset) {
+    // 应用预设时用该校 operators 整体替换下拉中的「预设预填」项。
+    // 上一所学校留下的 label/suffix（如南航「学生用户」）必须清掉，否则会串到
+    // 下一所学校；用户自建（custom）条目仍保留（与「复位」一致）。
+    function replacePresetOperators(preset) {
+      var kept = [];
+      for (var i = 0; i < operatorChoices.length; i++) {
+        if (operatorChoices[i].custom) kept.push(operatorChoices[i]);
+      }
+      operatorChoices = kept;
       var ops = (preset && preset.operators && preset.operators.length) ? preset.operators : [];
-      for (var i = 0; i < ops.length; i++) {
-        addOperatorChoice(operatorSuffixOf(ops[i]), String(ops[i].label || ''), false);
+      for (var j = 0; j < ops.length; j++) {
+        addOperatorChoice(operatorSuffixOf(ops[j]), String(ops[j].label || ''), false);
       }
       return ops;
     }
@@ -875,14 +882,22 @@
         if (!target) continue;
         target.value = (schoolDefaults[key] !== undefined && schoolDefaults[key] !== null) ? String(schoolDefaults[key]) : '';
       }
-      var nextOperators = mergePresetOperators(preset);
+      var nextOperators = replacePresetOperators(preset);
       var nextSuffix = nextOperators.length ? operatorSuffixOf(nextOperators[0]) : '';
       renderOperatorChoices(nextOperators.length ? nextSuffix : undefined);
       applyLoginShapeToForm(loginShape);
       presetApplied = true;
-      // 应用预设时，若该预设提供了运营商，则用第一个运营商联动填充后缀；否则保持手填。
+      // 应用预设时：有运营商则用第一个联动填充后缀；无运营商则清空后缀，避免残留旧校值。
       if (nextOperators.length) {
         applyOperatorPick();
+      } else {
+        var emptySuffix = document.getElementById('jm-operator_suffix');
+        if (emptySuffix) emptySuffix.value = '';
+        var emptyHint = document.getElementById('jm-operator-suffix-hint');
+        if (emptyHint) {
+          emptyHint.textContent = '';
+          emptyHint.style.display = 'none';
+        }
       }
       if (schoolDefaults.access_mode) {
         var modeSel = document.getElementById('jm-access_mode');

--- a/tests/test_luci_log_view_refactor.py
+++ b/tests/test_luci_log_view_refactor.py
@@ -175,6 +175,19 @@ class LuciLogViewRefactorTests(unittest.TestCase):
         self.assertNotIn("opId === 'xn' ? '' : opId", self.js_text)
         self.assertNotIn("不填则使用纯账号", self.js_text)
 
+    def test_apply_school_preset_replaces_operator_choices_not_merges(self):
+        # Switching school A -> school B must drop A's operators (e.g. nchu
+        # "学生用户"/stu.nchu.edu.cn) and install B's list; custom entries stay.
+        self.assertIn("function replacePresetOperators(preset)", self.js_text)
+        self.assertIn("var nextOperators = replacePresetOperators(preset)", self.js_text)
+        self.assertNotIn("function mergePresetOperators", self.js_text)
+        self.assertNotIn("mergePresetOperators(preset)", self.js_text)
+        # Non-custom rows are discarded before re-adding the new preset ops.
+        self.assertIn("if (operatorChoices[i].custom) kept.push(operatorChoices[i])", self.js_text)
+        self.assertIn("operatorChoices = kept", self.js_text)
+        # Empty operator list from a preset must clear leftover suffix text.
+        self.assertIn("if (emptySuffix) emptySuffix.value = ''", self.js_text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- **Bug:** Applying school preset A then B kept A's operator quick-pick entries (labels/suffixes). Example: apply 南昌航空 (`学生用户` / `stu.nchu.edu.cn`), then apply 江西师范大学 — the NCHU student-user option still appeared and was not appropriate for JXNU.
- **Cause:** `mergePresetOperators` only appended preset operators and never dropped the previous school's non-custom rows.
- **Fix:** Rename/replace with `replacePresetOperators`: discard non-custom choices, install the selected school's `operators`, keep user `custom` entries (same as reset). If the new preset has no operators, clear the suffix input so old values cannot linger.

## Test plan
- [x] `node --check root/www/luci-static/resources/smart_srun.js`
- [x] `python -m pytest tests/test_luci_log_view_refactor.py -v`
- [ ] LuCI: open campus account editor → apply 南昌航空 → confirm operator list shows 学生用户
- [ ] Then select 江西师范大学 → **应用预设** → list should be JXNU operators only (no leftover 学生用户 / `stu.nchu.edu.cn`); suffix field follows the first JXNU operator
- [ ] User-added custom operator (添加) still remains after switching schools
- [ ] 复位 still keeps custom operators and clears preset-filled ones