### PR TITLE
fix: 守护进程存活状态改用锁文件判断，不再依赖粘滞的 state 标记

### DIFF
--- a/root/usr/lib/lua/luci/controller/smart_srun.lua
+++ b/root/usr/lib/lua/luci/controller/smart_srun.lua
@@ -10,6 +10,7 @@ local schema = require "luci.smart_srun.schema"
 local STATE_FILE = "/var/run/smart_srun/state.json"
 local ACTION_FILE = "/var/run/smart_srun/action.json"
 local INFLIGHT_ACTION_FILE = "/var/run/smart_srun/action_inflight.json"
+local DAEMON_LOCK_FILE = "/var/run/smart_srun/daemon.lock"
 local LOG_FILE = "/var/log/smart_srun.log"
 local USER_PRESETS_FILE = "/usr/lib/smart_srun/user_presets.json"
 local USER_PRESETS_MAX_ITEMS = 50
@@ -182,6 +183,20 @@ local function collect_client_pids()
     return pids
 end
 
+-- state.daemon_running 只会被写成 true，守护进程被 SIGKILL / OOM / 断电打断后
+-- 这个标记会一直留着。守护进程持有的 flock 在进程死亡时由内核释放，所以用
+-- 锁文件里的 PID 加 cmdline 校验判断存活，PID 复用也不会误判。
+local function daemon_is_alive()
+    local pid = tostring(fs.readfile(DAEMON_LOCK_FILE) or ""):match("^%s*(%d+)")
+    if not pid then
+        return false
+    end
+
+    local cmdline = fs.readfile("/proc/" .. pid .. "/cmdline") or ""
+    cmdline = cmdline:gsub("%z", " ")
+    return cmdline:find("/usr/lib/smart_srun/client.py", 1, true) ~= nil
+end
+
 local function force_stop_client_processes()
     local pids = collect_client_pids()
     for _, pid in ipairs(pids) do
@@ -241,7 +256,7 @@ local function current_pending_runtime_action()
 
     local state = read_json_file(STATE_FILE)
     if tostring(state.action_result or "") == "pending" then
-        local daemon_running = state.daemon_running and true or false
+        local daemon_running = daemon_is_alive()
         local started_at = tonumber(state.action_started_at) or tonumber(state.last_action_ts) or 0
         if daemon_running or (started_at > 0 and (os.time() - started_at) < 15) then
             return tostring(state.pending_action or state.last_action or "")

--- a/root/usr/lib/smart_srun/daemon.py
+++ b/root/usr/lib/smart_srun/daemon.py
@@ -572,6 +572,51 @@ def _acquire_daemon_lock(max_wait_seconds=20):
     return lock_handle
 
 
+def _daemon_pid_from_lock():
+    try:
+        with open(DAEMON_LOCK_FILE, "r", encoding="utf-8") as handle:
+            return int((handle.read() or "").strip() or 0)
+    except (OSError, ValueError):
+        return 0
+
+
+def daemon_is_alive():
+    """Whether a daemon process is actually running right now.
+
+    state["daemon_running"] is only ever written True, so an abnormal exit
+    (SIGKILL, OOM, power loss) leaves it set for the rest of the boot and
+    every later status read reports a dead daemon as running. The kernel
+    drops the flock held by run_daemon() when that process dies, so the
+    lock -- not the state flag -- is the authoritative signal.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        fcntl = None
+
+    if fcntl is None:
+        pid = _daemon_pid_from_lock()
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
+
+    try:
+        with open(DAEMON_LOCK_FILE, "r", encoding="utf-8") as handle:
+            try:
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                # Still held: a live daemon owns the lock.
+                return True
+            fcntl.flock(handle, fcntl.LOCK_UN)
+    except OSError:
+        return False
+    return False
+
+
 def run_daemon(runtime=None):
     _daemon_lock = _acquire_daemon_lock()
     reconcile_manual_login_service_guard()
@@ -802,7 +847,7 @@ def _show_status(cfg):
     interval = raw.get("interval", "60")
     enabled = raw.get("enabled", "0") == "1"
     in_quiet = state.get("in_quiet", False)
-    daemon_running = state.get("daemon_running", False)
+    daemon_running = daemon_is_alive()
 
     if ok and conn_level == "online":
         status_str = "在线"

--- a/tests/test_daemon_liveness.py
+++ b/tests/test_daemon_liveness.py
@@ -1,0 +1,88 @@
+import fcntl
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_ROOT = os.path.join(REPO_ROOT, "root", "usr", "lib", "smart_srun")
+
+if MODULE_ROOT not in sys.path:
+    sys.path.insert(0, MODULE_ROOT)
+
+
+import daemon
+
+
+class DaemonLivenessTests(unittest.TestCase):
+    """state['daemon_running'] is only ever written True.
+
+    An abnormal exit (SIGKILL / OOM / power loss) leaves it set, so status
+    kept reporting a dead daemon as running. Liveness now comes from the
+    flock that run_daemon() holds, which the kernel drops on death.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.lock_path = os.path.join(self._tmp.name, "daemon.lock")
+
+    def _patch_lock(self):
+        return mock.patch.object(daemon, "DAEMON_LOCK_FILE", self.lock_path)
+
+    def test_missing_lock_file_reports_not_alive(self):
+        with self._patch_lock():
+            self.assertFalse(daemon.daemon_is_alive())
+
+    def test_stale_unlocked_lock_file_reports_not_alive(self):
+        with open(self.lock_path, "w", encoding="utf-8") as handle:
+            handle.write("999999")
+
+        with self._patch_lock():
+            self.assertFalse(daemon.daemon_is_alive())
+
+    def test_held_lock_reports_alive(self):
+        with open(self.lock_path, "a+", encoding="utf-8") as holder:
+            fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self._patch_lock():
+                self.assertTrue(daemon.daemon_is_alive())
+
+    def test_released_lock_reports_not_alive_again(self):
+        with open(self.lock_path, "a+", encoding="utf-8") as holder:
+            fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with self._patch_lock():
+                self.assertTrue(daemon.daemon_is_alive())
+                fcntl.flock(holder, fcntl.LOCK_UN)
+                self.assertFalse(daemon.daemon_is_alive())
+
+    def test_status_reports_stopped_when_state_flag_is_stale(self):
+        stale_state = {
+            "daemon_running": True,
+            "connectivity": "互联网可达",
+            "connectivity_level": "online",
+            "current_ip": "10.0.0.2",
+            "current_ssid": "campus",
+            "mode_label": "校园网模式",
+            "campus_account_label": "someone",
+        }
+        cfg = {"enabled": "1", "interval": "60"}
+
+        with self._patch_lock(), \
+                mock.patch("config.load_runtime_state", return_value=stale_state), \
+                mock.patch.object(
+                    daemon.orchestrator, "run_status", return_value=(True, "在线")
+                ):
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                daemon._show_status(cfg)
+
+        output = buffer.getvalue()
+        self.assertIn("守护:   已停止", output)
+        self.assertNotIn("守护:   运行中", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`state["daemon_running"]` 实际上只会被写成 `true`：`daemon.py` 在启动和每次 tick 时都会更新它，但进程退出时没有任何逻辑负责复位。

因此，只要守护进程不是通过 LuCI 的 `handle_force_stop()` 停掉，例如遭遇 SIGKILL、OOM、procd 放弃重启或设备断电，`daemon_running` 就会一直保持 `true`，直到本次启动周期结束。

这会带来两个问题：

* `srunnet status` 会把已经不存在的守护进程显示成 `守护: 运行中`；
* `current_pending_runtime_action()` 也会认为守护进程仍然能够处理排队动作，导致 LuCI 界面一直停在“待执行”。

后一个问题和 `controller/smart_srun.lua` 里已有注释描述的是同一类故障：

```lua
-- 丢弃滞留动作时必须同步收敛 state，否则 action_result 会一直停在
-- pending，界面永远显示"待执行"（旧版正是这样卡死的）。
```

之前修复的是滞留 action 本身，但 `current_pending_runtime_action()` 仍然依赖 `state.daemon_running`，所以守护进程异常退出后，另一条路径依然可能把界面卡在“待执行”。

## 原因

Python 侧对 `daemon_running` 的写入只有 `true`：

```text
daemon.py:599  daemon_running=True,      # 启动
daemon.py:654  daemon_running=True,      # tick
daemon.py:669  daemon_running=True,
daemon.py:687  daemon_running=True,
daemon.py:805  daemon_running = state.get("daemon_running", False)  # 读取
```

没有退出钩子负责把它改回 `false`。目前唯一会写入 `false` 的地方是 LuCI 的 `handle_force_stop()`，也就是说，只有用户主动执行“强制关闭”时这个状态才会被收敛。

但 `run_daemon()` 在整个生命周期内本来就会持有 `/var/run/smart_srun/daemon.lock` 的排他 `flock`。进程一旦死亡，内核会自动释放这把锁，因此锁本身比 `state.json` 中的状态字段更适合作为守护进程是否存活的依据。

## 改动

### Python：`daemon.py`

新增 `daemon_is_alive()`：

* 对 `daemon.lock` 尝试非阻塞 `LOCK_EX`；
* 无法取得锁，说明当前有守护进程持有它，返回存活；
* 能取得锁，说明没有守护进程持锁，立即释放并关闭 fd；
* 在没有 `fcntl` 的环境中，退回读取锁文件 PID，并通过 `os.kill(pid, 0)` 检查进程是否存在。

`_show_status()` 不再读取 `state["daemon_running"]`，统一改为调用 `daemon_is_alive()`。

### LuCI：`controller/smart_srun.lua`

新增 `daemon_is_alive()`：

* 从 `daemon.lock` 读取 PID；
* 检查对应的 `/proc/<pid>` 是否存在；
* 再校验 `/proc/<pid>/cmdline` 是否仍然指向 `client.py`。

这样即使锁文件里留下的 PID 后续被其他进程复用，也不会把无关进程误判成正在运行的守护进程。

`current_pending_runtime_action()` 随之改用 `daemon_is_alive()`，不再依赖 `state.daemon_running`。

## status 路径短暂取得锁的影响

这里的试锁不会影响守护进程正常启动。

`_acquire_daemon_lock()` 本身就会重试 20 秒，用来处理 service restart 时旧实例尚未完全退出的情况：

```python
# 手动动作会触发 service restart，procd 拉起新实例时旧实例可能还差
# 一两秒才退出。立刻放弃会白白烧掉 procd 的 respawn 预算...
```

因此，即使 `status` 恰好在守护进程启动的瞬间短暂取得了锁，新实例也会继续重试，不会因为这一瞬间的竞争直接退出并消耗 respawn 预算。

这里使用的是 `flock`。status 路径通过独立的 open/close 完成试锁，不会释放或干扰守护进程自己 fd 上持有的锁。

## 测试

新增 `tests/test_daemon_liveness.py`，覆盖 5 种情况：

* 锁文件不存在；
* 锁文件存在但没有加锁；
* 锁被其他 fd 持有；
* 锁释放后重新判断；
* `state["daemon_running"]` 已经 stale 时，`_show_status()` 仍必须输出 `守护: 已停止`。

测试结果：

```text
python -m pytest tests/ -q
221 passed, 2 skipped

ruff check root/usr/lib/smart_srun/daemon.py
# 与修改前相同，仍为 86 项，无新增
```

回退本次修复后，新增的 5 个测试全部失败。其中关键用例会直接报：

```text
'守护:   已停止' not found in ... 守护:   运行中
```

因此这些测试能够实际覆盖本次修复，而不是只验证了无关路径。

Lua 侧本地环境没有 `lua` 解释器，所以 `tests/test_lua_syntax.py` 显示为 skip，不能算作本地语法检查通过。

随后在路由器上使用真实 `lua` 完成了语法检查，并通过 `nixio.fs` 实测以下 5 个边界情况：

* stale PID；
* 锁文件不存在；
* PID 对应的进程存活，但不是守护进程；
* 锁文件内容不是数字；
* 空锁文件。

以上情况均正确返回 `false`。

## 实机验证

环境：ImmortalWrt 24.10 / MT7981。

先 kill 掉守护进程，保留 stale 状态：

```text
daemon.lock          = 16307
/proc/16307           不存在
state.json            "daemon_running": true
ps | grep client.py   0 个进程
```

修复前：

```text
srunnet status
守护: 运行中
```

修复后：

```text
srunnet status
守护: 已停止
```

随后重新正常启动服务，`srunnet status` 仍能正确显示 `守护: 运行中`。
