### PR TITLE
fix: portal detect 缺少 idna 编解码器时回退到系统 HTTP 客户端

### DIFF
--- a/root/usr/lib/smart_srun/portal_detect.py
+++ b/root/usr/lib/smart_srun/portal_detect.py
@@ -75,9 +75,35 @@ class _NoRedirectHandler(urllib_request.HTTPRedirectHandler if urllib_request el
         return None
 
 
-def _fetch_once(url, timeout):
+def _stdlib_http_is_usable():
+    """OpenWrt python3-light ships urllib but often omits the idna codec.
+
+    Hostname encoding then raises LookupError('unknown encoding: idna')
+    before any network IO, so detect it up front and let the system HTTP
+    client (uclient-fetch / wget) run the probe instead.
+    """
     if not HAVE_URLLIB or not urllib_request:
-        return 200, {}, http_get(url, timeout=timeout)
+        return False
+    try:
+        "example.com".encode("idna")
+    except LookupError:
+        return False
+    return True
+
+
+def _fetch_via_system_client(url, timeout):
+    """Probe without stdlib networking.
+
+    uclient-fetch / wget follow redirects themselves, so no response headers
+    are available and the body is already the final landing page. _probe_url
+    still finds AC_ID via the HTML patterns.
+    """
+    return 200, {}, http_get(url, timeout=timeout)
+
+
+def _fetch_once(url, timeout):
+    if not _stdlib_http_is_usable():
+        return _fetch_via_system_client(url, timeout)
 
     opener = urllib_request.build_opener(_NoRedirectHandler)
     req = urllib_request.Request(url, headers=HEADER, method="GET")
@@ -91,6 +117,9 @@ def _fetch_once(url, timeout):
     except urllib_error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
         return exc.code, dict(exc.headers.items()), body
+    except LookupError:
+        # idna / codec path can still fail late on some builds.
+        return _fetch_via_system_client(url, timeout)
     except Exception as exc:
         raise RuntimeError(humanize_http_errors(url, [exc]))
 

--- a/tests/test_portal_detect.py
+++ b/tests/test_portal_detect.py
@@ -62,5 +62,69 @@ class PortalDetectTests(unittest.TestCase):
         self.assertIn("python3-openssl", message)
 
 
+class PortalDetectIdnaFallbackTests(unittest.TestCase):
+    """python3-light ships urllib but usually omits the idna codec.
+
+    Hostname encoding then raises LookupError before any network IO, which
+    used to surface as 'unknown encoding: idna' instead of probing AC_ID.
+    """
+
+    def test_stdlib_probe_reports_unusable_when_urllib_missing(self):
+        with mock.patch.object(portal_detect, "HAVE_URLLIB", False):
+            self.assertFalse(portal_detect._stdlib_http_is_usable())
+
+        with mock.patch.object(portal_detect, "urllib_request", None):
+            self.assertFalse(portal_detect._stdlib_http_is_usable())
+
+    def test_stdlib_probe_reports_usable_when_idna_codec_present(self):
+        self.assertTrue("example.com".encode("idna"))
+        self.assertTrue(portal_detect._stdlib_http_is_usable())
+
+    def test_fetch_once_falls_back_to_system_client_without_idna(self):
+        with mock.patch.object(
+            portal_detect, "_stdlib_http_is_usable", return_value=False
+        ), mock.patch.object(
+            portal_detect, "http_get", return_value='<input name="ac_id" value="12">'
+        ) as fake_get:
+            status, headers, body = portal_detect._fetch_once(PORTAL_ORIGIN, 5)
+
+        fake_get.assert_called_once_with(PORTAL_ORIGIN, timeout=5)
+        self.assertEqual(status, 200)
+        self.assertEqual(headers, {})
+        self.assertIn("ac_id", body)
+
+    def test_detect_acid_succeeds_via_system_client_without_idna(self):
+        with mock.patch.object(
+            portal_detect, "_stdlib_http_is_usable", return_value=False
+        ), mock.patch.object(
+            portal_detect, "http_get", return_value='<input name="ac_id" value="12">'
+        ):
+            payload = portal_detect.detect_acid(PORTAL_ORIGIN)
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["acid"], "12")
+        self.assertEqual(payload["source"], "html")
+        self.assertNotIn("idna", payload["message"])
+
+    def test_late_lookup_error_falls_back_instead_of_raising(self):
+        class _Opener:
+            def open(self, *args, **kwargs):
+                raise LookupError("unknown encoding: idna")
+
+        with mock.patch.object(
+            portal_detect, "_stdlib_http_is_usable", return_value=True
+        ), mock.patch.object(
+            portal_detect.urllib_request, "build_opener", return_value=_Opener()
+        ), mock.patch.object(
+            portal_detect, "http_get", return_value='<input name="ac_id" value="7">'
+        ) as fake_get:
+            status, headers, body = portal_detect._fetch_once(PORTAL_ORIGIN, 5)
+
+        fake_get.assert_called_once_with(PORTAL_ORIGIN, timeout=5)
+        self.assertEqual(status, 200)
+        self.assertEqual(headers, {})
+        self.assertIn("ac_id", body)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 问题

在只安装 `python3-light` 的 OpenWrt 上执行：

```text
srunnet detect acid
```

会直接报错：

```text
无法访问认证网关 <host>：与网关通信失败。技术详情：unknown encoding: idna
```

此时 AC_ID 探测无法继续，CLI 和 LuCI 都不能自动获取参数。

## 原因

`python3-light` 自带 urllib，但没有 `idna` 编解码器。`idna` 由 `python3-codecs` 提供，而后者并不是当前软件包的依赖。

所以 urllib 本身可以正常 import，真正访问 URL 时却会在处理主机名阶段抛出：

```text
LookupError('unknown encoding: idna')
```

这个异常发生在任何网络 IO 之前。

`portal_detect._fetch_once()` 原来的回退条件只有：

```python
if not HAVE_URLLIB or not urllib_request:
    return 200, {}, http_get(url, timeout=timeout)
```

但 `HAVE_URLLIB` 只能反映 urllib 在 import 阶段是否存在。当前情况属于“能 import，但运行时缺 codec”，因此不会进入这个分支。

后续的 `LookupError` 会落到通用 `except Exception`，最终被包装成 `RuntimeError` 返回给用户，也就没有机会尝试系统 HTTP 客户端。

实际上，同一台设备上的 `network.http_get()` 可以正常通过 `uclient-fetch` / `wget` 完成请求。

仓库里已经有两处处理过同类问题：

* `updater._stdlib_http_is_usable()`：#26，`fix: fall back to wget when updater lacks idna codec`
* `school_presets._fetch_remote_payload_with_source()`：stdlib 请求失败后回退 `_fetch_via_system_client()`

`portal_detect.py` 之前没有做这层处理。

## 改动

新增 `_stdlib_http_is_usable()`，沿用 `updater.py` 的做法，通过：

```python
"example.com".encode("idna")
```

提前检查当前 Python 环境的 urllib 路径是否真的可用。

同时新增 `_fetch_via_system_client()`，统一通过 `network.http_get()` 调用系统的 `uclient-fetch` / `wget`。

`_fetch_once()` 现在会在预检失败时直接走系统客户端；stdlib 请求过程中如果仍然出现 `LookupError`，也会再次回退。

后面这一层仍然需要保留，因为部分固件上的 codec 问题可能直到实际处理 URL 时才暴露，单靠预检不能完全覆盖。

## 回退路径的响应处理

`uclient-fetch` / `wget` 会自行跟随重定向，因此这条路径拿不到中间响应头，返回值仍按原有约定处理为：

```text
(200, {}, body)
```

不过此时 `body` 已经是重定向后的最终页面，`_probe_url()` 仍然可以从 HTML 中匹配并提取 AC_ID。

原来的 `not HAVE_URLLIB` 分支本身就是按这个行为工作的，因此这次只是把“urllib 存在但实际不可用”的情况也接入同一条回退路径。

## 测试

新增 `PortalDetectIdnaFallbackTests`，共 5 个用例，覆盖：

* urllib 不可用时的预检结果；
* urllib 可用时的预检结果；
* `_fetch_once()` 的系统客户端回退；
* `detect_acid` 端到端不再返回 `idna` 错误；
* urllib 在实际请求阶段抛出 `LookupError` 时仍能回退。

测试结果：

```text
python -m pytest tests/ -q
221 passed, 2 skipped

ruff check root/usr/lib/smart_srun/portal_detect.py
# 与修改前相同，仍为 8 项，无新增
```

回退本次修复后，新增的 5 个用例全部失败，确认测试确实覆盖了这次修改。

## 实机验证

环境：

```text
ImmortalWrt 24.10
MediaTek MT7981
python3-light 3.11.14
未安装 python3-codecs
```

修复前：

```text
srunnet detect acid
→ 技术详情：unknown encoding: idna
```

修复后会自动回退到 wget，并成功抓取 5813 字节页面内容，探测流程可以正常完成。

该校园门户页面本身没有提供 AC_ID，因此最终结果为：

```text
未从认证地址、跳转链或页面中发现 AC_ID
```

这是正常的探测结果；关键是请求已经成功完成，不再因为缺少 `idna` codec 提前报错。
