### PR TITLE
fix: 支持节名不是 radioN 的无线射频（MediaTek mtwifi）

### DIFF
--- a/root/usr/lib/smart_srun/wireless.py
+++ b/root/usr/lib/smart_srun/wireless.py
@@ -214,16 +214,40 @@ def get_sta_profile_from_section(section, wireless_data=None):
 # ---------------------------------------------------------------------------
 
 
+def parse_wifi_device_sections(uci_output):
+    """wifi-device 的节名不一定叫 radioN。
+
+    mac80211 用 radio0/radio1，但 MediaTek 闭源 mtwifi（MT798x 等）用的是
+    MT7981_1_1 / MT7981_1_2 这种名字。只能按节类型认，不能按名字猜。
+    """
+    devices = []
+    seen = set()
+    for line in str(uci_output or "").splitlines():
+        match = re.match(r"^wireless\.([^.=]+)=(?:'|\")?wifi-device(?:'|\")?$", line.strip())
+        if not match:
+            continue
+        name = match.group(1)
+        if name not in seen:
+            devices.append(name)
+            seen.add(name)
+    return devices
+
+
 def parse_radio_bands():
     ok, out = run_cmd(["uci", "show", "wireless"])
     if not ok or not out:
         return {}
+
+    devices = set(parse_wifi_device_sections(out))
     bands = {}
     for line in out.splitlines():
-        m = re.match(r"^wireless\.(radio\d+)\.(band|hwmode)=(.+)$", line.strip())
+        m = re.match(r"^wireless\.([^.=]+)\.(band|hwmode)=(.+)$", line.strip())
         if not m:
             continue
         radio, opt, val = m.groups()
+        # 只认真正的 wifi-device 节，别把 wifi-iface 上的同名选项算进来。
+        if devices and radio not in devices:
+            continue
         val = parse_uci_value(val).lower()
         if opt == "band":
             bands[radio] = val
@@ -248,16 +272,8 @@ def get_available_wifi_radios(wireless_data=None):
     if not ok or not out:
         return []
 
-    seen = set()
-    for line in out.splitlines():
-        match = re.match(r"^wireless\.(radio\d+)\.=wifi-device$", line.strip())
-        if not match:
-            continue
-        radio = match.group(1)
-        if radio not in seen:
-            radios.append(radio)
-            seen.add(radio)
-    return radios
+    # 没有 band/hwmode 时退回按节类型枚举。
+    return parse_wifi_device_sections(out)
 
 
 def band_label(band):

--- a/tests/test_wireless_radio_detection.py
+++ b/tests/test_wireless_radio_detection.py
@@ -1,0 +1,149 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_ROOT = os.path.join(REPO_ROOT, "root", "usr", "lib", "smart_srun")
+
+if MODULE_ROOT not in sys.path:
+    sys.path.insert(0, MODULE_ROOT)
+
+
+import wireless
+
+# Real `uci show wireless` shape on a mac80211 device (radio0 / radio1).
+MAC80211_UCI = """wireless.radio0=wifi-device
+wireless.radio0.type='mac80211'
+wireless.radio0.band='2g'
+wireless.radio0.channel='auto'
+wireless.default_radio0=wifi-iface
+wireless.default_radio0.device='radio0'
+wireless.default_radio0.mode='ap'
+wireless.radio1=wifi-device
+wireless.radio1.type='mac80211'
+wireless.radio1.band='5g'
+wireless.default_radio1=wifi-iface
+wireless.default_radio1.device='radio1'
+wireless.default_radio1.mode='ap'
+"""
+
+# Real `uci show wireless` shape on MediaTek mtwifi (MT7981, ImmortalWrt 24.10).
+MTWIFI_UCI = """wireless.MT7981_1_1=wifi-device
+wireless.MT7981_1_1.type='mtwifi'
+wireless.MT7981_1_1.phy='ra0'
+wireless.MT7981_1_1.hwmode='11g'
+wireless.MT7981_1_1.band='2g'
+wireless.default_MT7981_1_1=wifi-iface
+wireless.default_MT7981_1_1.device='MT7981_1_1'
+wireless.default_MT7981_1_1.mode='ap'
+wireless.MT7981_1_2=wifi-device
+wireless.MT7981_1_2.type='mtwifi'
+wireless.MT7981_1_2.phy='rax0'
+wireless.MT7981_1_2.hwmode='11a'
+wireless.MT7981_1_2.band='5g'
+wireless.default_MT7981_1_2=wifi-iface
+wireless.default_MT7981_1_2.device='MT7981_1_2'
+wireless.default_MT7981_1_2.mode='ap'
+wireless.wifinet2=wifi-iface
+wireless.wifinet2.device='MT7981_1_2'
+wireless.wifinet2.mode='sta'
+wireless.wifinet2.ssid='campus'
+"""
+
+# hwmode only, no band -- older configs.
+HWMODE_ONLY_UCI = """wireless.MT7981_1_1=wifi-device
+wireless.MT7981_1_1.hwmode='11g'
+wireless.MT7981_1_2=wifi-device
+wireless.MT7981_1_2.hwmode='11a'
+"""
+
+# wifi-device sections with neither band nor hwmode -- exercises the fallback.
+NO_BAND_UCI = """wireless.MT7981_1_1=wifi-device
+wireless.MT7981_1_1.type='mtwifi'
+wireless.MT7981_1_2=wifi-device
+wireless.MT7981_1_2.type='mtwifi'
+wireless.wifinet2=wifi-iface
+wireless.wifinet2.device='MT7981_1_2'
+"""
+
+
+class WifiDeviceSectionTests(unittest.TestCase):
+    def test_parses_mac80211_radio_names(self):
+        self.assertEqual(
+            wireless.parse_wifi_device_sections(MAC80211_UCI), ["radio0", "radio1"]
+        )
+
+    def test_parses_mtwifi_vendor_radio_names(self):
+        self.assertEqual(
+            wireless.parse_wifi_device_sections(MTWIFI_UCI),
+            ["MT7981_1_1", "MT7981_1_2"],
+        )
+
+    def test_ignores_wifi_iface_sections(self):
+        self.assertNotIn("wifinet2", wireless.parse_wifi_device_sections(MTWIFI_UCI))
+        self.assertNotIn(
+            "default_MT7981_1_1", wireless.parse_wifi_device_sections(MTWIFI_UCI)
+        )
+
+    def test_empty_output(self):
+        self.assertEqual(wireless.parse_wifi_device_sections(""), [])
+        self.assertEqual(wireless.parse_wifi_device_sections(None), [])
+
+
+class RadioDetectionTests(unittest.TestCase):
+    """MediaTek mtwifi names radios MT7981_1_1/_1_2, not radio0/radio1.
+
+    The old regexes hardcoded radioN, so detection returned nothing and
+    ensure_runtime_wireless_prerequisites reported
+    '当前路由器未发现可用无线射频' on every reconnect attempt.
+    """
+
+    def _with_uci(self, text):
+        return mock.patch.object(wireless, "run_cmd", return_value=(True, text))
+
+    def test_mac80211_bands_still_detected(self):
+        with self._with_uci(MAC80211_UCI):
+            self.assertEqual(
+                wireless.parse_radio_bands(), {"radio0": "2g", "radio1": "5g"}
+            )
+            self.assertEqual(
+                wireless.get_available_wifi_radios(), ["radio1", "radio0"]
+            )
+
+    def test_mtwifi_bands_detected(self):
+        with self._with_uci(MTWIFI_UCI):
+            self.assertEqual(
+                wireless.parse_radio_bands(),
+                {"MT7981_1_1": "2g", "MT7981_1_2": "5g"},
+            )
+
+    def test_mtwifi_radios_are_found_5g_first(self):
+        with self._with_uci(MTWIFI_UCI):
+            self.assertEqual(
+                wireless.get_available_wifi_radios(),
+                ["MT7981_1_2", "MT7981_1_1"],
+            )
+
+    def test_hwmode_only_is_mapped_to_bands(self):
+        with self._with_uci(HWMODE_ONLY_UCI):
+            self.assertEqual(
+                wireless.parse_radio_bands(),
+                {"MT7981_1_1": "2g", "MT7981_1_2": "5g"},
+            )
+
+    def test_fallback_enumerates_devices_without_band(self):
+        with self._with_uci(NO_BAND_UCI):
+            self.assertEqual(wireless.parse_radio_bands(), {})
+            self.assertEqual(
+                wireless.get_available_wifi_radios(),
+                ["MT7981_1_1", "MT7981_1_2"],
+            )
+
+    def test_no_radios_when_uci_unavailable(self):
+        with mock.patch.object(wireless, "run_cmd", return_value=(False, "")):
+            self.assertEqual(wireless.get_available_wifi_radios(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

在使用 MediaTek 闭源 `mtwifi` 驱动的 MT798x 设备（Cudy TR3000）上，插件会报：

```text
当前路由器未发现可用无线射频，请先确认无线功能已启用。
```

ImmortalWrt 的 mt798x target 就会遇到这个问题。正常联网时不一定能发现异常，但一旦 STA 掉线或无线配置发生变化，守护进程就无法重新找到射频，自动重连随之失效。

## 原因

`mtwifi` 使用的 wifi-device 节名不是 mac80211 常见的 `radio0` / `radio1`，而是类似：

```text
MT7981_1_1
MT7981_1_2
```

原来的两处射频查找都把节名限制成了 `radioN`：

```python
# parse_radio_bands()
r"^wireless\.(radio\d+)\.(band|hwmode)=(.+)$"

# get_available_wifi_radios() 的兜底
r"^wireless\.(radio\d+)\.=wifi-device$"
```

因此在 mtwifi 上：

```text
parse_radio_bands()         = {}
get_available_wifi_radios() = []
```

随后 `ensure_runtime_wireless_prerequisites()` 判断设备没有可用射频并返回错误。

第二条正则本身还有一个独立问题。`uci show wireless` 对 wifi-device 的输出格式是：

```text
wireless.radio0=wifi-device
```

`=` 前没有 `.`，而原来的正则要求匹配 `\.=wifi-device`，所以这个兜底实际上无法命中。mac80211 设备之前没有暴露这个问题，是因为前面的 `band` 检测通常已经成功，根本用不到这条兜底路径。

## 为什么正常联网时不容易发现

`ensure_expected_profile()` 在以下条件都满足时会直接返回：

* profile 已经匹配；
* STA 已取得 IPv4；
* 接口处于启用状态。

这条正常路径不会继续执行射频检查，所以设备已经连上网时看起来没有异常。

只有 profile 漂移，或者 STA 丢失 IPv4、需要重新建立连接时，代码才会真正走到射频检测。此时 mtwifi 的节名无法被识别，守护进程就会在后续 tick 中反复重试，并持续记录“未发现可用无线射频”。

也就是说，这个问题主要出现在守护进程真正需要执行重连的时候。

## 改动

新增 `parse_wifi_device_sections()`，直接根据 UCI 节类型：

```text
=wifi-device
```

识别所有无线射频，不再假定节名必须符合 `radioN`。

`parse_radio_bands()` 先通过这个函数确定实际的 wifi-device 节，再从这些节中读取 `band` / `hwmode`。这样既能支持 `MT7981_1_1` 这类 mtwifi 命名，也不会误把 wifi-iface 上同名的 `band` 或 `hwmode` 选项当成射频信息。

`get_available_wifi_radios()` 的兜底同样改为复用 `parse_wifi_device_sections()`，同时移除原来无法匹配的 `\.=wifi-device` 正则。

射频排序逻辑没有变化，仍然使用：

```python
sorted(..., reverse=True)
```

因此现有的 5GHz 优先顺序保持不变。

## 测试

新增 `tests/test_wireless_radio_detection.py`，共 10 个用例，样本使用真实的 `uci show wireless` 输出，覆盖：

* mac80211 的 `radio0` / `radio1`，确保现有路径不回归；
* mtwifi 的 `MT7981_1_1` / `MT7981_1_2`；
* 只有 `hwmode`、没有 `band` 的旧配置；
* wifi-device 同时缺少 `band` 和 `hwmode` 时的兜底枚举；
* 忽略 wifi-iface / `default_*` 节；
* UCI 不可用。

测试结果：

```text
python -m pytest tests/ -q
226 passed, 2 skipped

ruff check root/usr/lib/smart_srun/wireless.py
# 与修改前相同，仍为 50 项，无新增
```

回退本次修复后，10 个新增用例中有 8 个失败。

仍然通过的 2 个是 mac80211 用例，也符合预期：原来的实现本来就能识别标准 `radioN` 命名，这次修复针对的是此前覆盖不到的节名和兜底路径。

## 实机验证

环境：

```text
ImmortalWrt 24.10
MediaTek MT7981
mtwifi 驱动
接口：apcli0 / apclix0 / ra0 / rax0
```

修复前：

```text
parse_radio_bands()          = {}
get_available_wifi_radios()  = []
prerequisites                = False, "当前路由器未发现可用无线射频，请先确认无线功能已启用。"
```

修复后：

```text
parse_radio_bands()          = {'MT7981_1_1': '2g', 'MT7981_1_2': '5g'}
get_available_wifi_radios()  = ['MT7981_1_2', 'MT7981_1_1']
prerequisites                = True
```

mtwifi 的两个射频现在都能正常识别，前置检查也可以通过；mac80211 的 `radioN` 路径保持原有行为。
