### PR TITLE
chore: remove unused runtime paths and credit contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 本仓库是 OpenWrt 包源码，不是普通单体应用。真正随包安装的内容都在 `root/` 下；`tests/`、`scripts/` 和 `doc/` 只用于开发、验证和维护。
 
+## 提交署名与 PR 整理
+
+- 提交前检查 `git config user.name` 和 `git config user.email`，使用本人已关联 GitHub 的邮箱或本人设置页提供的 noreply 邮箱，不要复制维护者的邮箱。GitHub 贡献统计按提交邮箱关联账号，PR 作者与提交作者可以不同。
+- 合并外部贡献前核对提交作者和 GitHub 账号关联，保留原贡献者署名；解决冲突的提交由实际处理者署名。已合并的历史不为整理界面而重写。
+- 每个主题使用一条短期分支和一个 PR；同一 PR 内继续修正，合并并确认无待保留工作后删除源分支。自己的零散修正可在合并时 squash，合并前检查最终署名与变更范围。
+- `main` 保留开发历史，`downloads` 提供在线升级包；已合并 PR 是历史记录，日常处理使用 [Open PR 列表](https://github.com/matthewlu070111/smart-srun/pulls?q=is%3Apr+is%3Aopen)。
+
+若邮箱属于本人但未关联账号，可在 GitHub 的邮件设置中添加该邮箱；若误用了他人邮箱，先修正后续提交配置。维护者无法代替贡献者绑定邮箱，也不应通过空提交或虚假署名补贡献数。详见 [GitHub 贡献者统计说明](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-a-projects-contributors)。
+
 ## 项目结构
 
 ```text

--- a/README.md
+++ b/README.md
@@ -243,3 +243,6 @@ DHCP 地址位于 `wan.v2`，就在 LuCI 的账号编辑框中选择“有线（
 [WTFPL](LICENSE)
 ## 参与贡献
 如果你愿意参与开发：请参阅 [贡献指南](CONTRIBUTING.md)
+
+感谢 [@haohaoget](https://github.com/haohaoget) 提供多 WAN 并行认证（[#31](https://github.com/matthewlu070111/smart-srun/pull/31)），以及 [@shijia257](https://github.com/shijia257) 提供校园账号绑定网络接口（[#32](https://github.com/matthewlu070111/smart-srun/pull/32)）。
+更多代码贡献见[已合并的 PR](https://github.com/matthewlu070111/smart-srun/pulls?q=is%3Apr+is%3Amerged) 与[贡献者列表](https://github.com/matthewlu070111/smart-srun/graphs/contributors)。问题反馈与学校数据提供者也记录在对应 Issue 和学校预设中。

--- a/root/usr/lib/lua/luci/controller/smart_srun.lua
+++ b/root/usr/lib/lua/luci/controller/smart_srun.lua
@@ -322,10 +322,6 @@ end
 -- 表格 CRUD 需要的配置读写
 local CONFIG_FILE = "/usr/lib/smart_srun/config.json"
 
-local GLOBAL_SCALAR_KEYS_SET = schema.global_scalar_key_set()
-local POINTER_KEYS_LIST = schema.POINTER_KEYS
-local LIST_KEYS_LIST = schema.LIST_KEYS
-
 local function load_config_json_unlocked()
     local raw = fs.readfile(CONFIG_FILE) or "{}"
     local parsed = jsonc.parse(raw)
@@ -1172,9 +1168,7 @@ local function append_message_detail(parts, rest, has_prior_detail)
     local detail = rest:match("|%s*(.+)$")
     if detail and detail ~= "" then
         parts[#parts + 1] = (has_prior_detail and " · " or ": ") .. detail
-        return true
     end
-    return has_prior_detail
 end
 
 local function skip_fields(...)
@@ -1204,8 +1198,6 @@ function friendly_line(line)
         parts[#parts + 1] = "[警告] "
     elseif level == "DEBUG" then
         parts[#parts + 1] = "[调试] "
-    elseif level == "INFO" then
-        parts[#parts + 1] = "[信息] "
     else
         parts[#parts + 1] = "[信息] "
     end

--- a/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
+++ b/root/usr/lib/lua/luci/model/cbi/smart_srun.lua
@@ -299,13 +299,12 @@ end
 
 local RADIO_CHOICES = load_radio_choices()
 
-local function render_school_info_html(schools, current_school)
+local function render_school_info_html()
     local helper_prefix = "如果该配置无法在您的学校使用，请直接前往"
     local helper_suffix = "提交 Issue 或 PR"
     local helper_link = "https://github.com/matthewlu070111/smart-srun"
     -- 初始渲染统一指向 doc 目录（永不 404）；前端 JS 会按预设的 doc_url 覆写为具体文档。
     local doc_url = "https://github.com/matthewlu070111/smart-srun/tree/main/doc"
-    local js_data = jsonc.stringify(schools or {}) or "[]"
 
     return string.format([[
 <div id="smart-school-info" class="cbi-value-description" style="color:#14532d;opacity:0.9;display:block;line-height:1.6;">
@@ -315,14 +314,12 @@ local function render_school_info_html(schools, current_school)
   <div id="smart-school-helper" style="display:block;margin-top:4px;color:#6b7280;font-size:0.92em;">
     %s<a id="smart-school-repo-link" href="%s" target="_blank" rel="noopener noreferrer">插件仓库</a>%s
   </div>
-  <textarea id="smart-school-data" style="display:none;">%s</textarea>
 </div>
 ]],
         doc_url,
         helper_prefix,
         helper_link,
-        helper_suffix,
-        util.pcdata(js_data))
+        helper_suffix)
 end
 
 local function ensure_school_extra_table()
@@ -632,7 +629,7 @@ function school.write(self, section, value)
     end
     set_value("school", next_school)
 end
-school.description = render_school_info_html(schools, cfg.school or "default")
+school.description = render_school_info_html()
 
 if school_runtime_renderable then
     for idx, descriptor in ipairs(school_runtime_descriptors) do

--- a/root/usr/lib/smart_srun/config.py
+++ b/root/usr/lib/smart_srun/config.py
@@ -709,20 +709,6 @@ def save_runtime_status(message, state=None, **extra):
 # ---------------------------------------------------------------------------
 
 
-def queue_runtime_action(action):
-    payload = {
-        "action": str(action or "").strip(),
-        "requested_at": int(time.time()),
-    }
-    save_json_file(ACTION_FILE, payload)
-    log(
-        "DEBUG",
-        "config_action_queued",
-        action=payload["action"],
-        requested_at=payload["requested_at"],
-    )
-
-
 def pop_runtime_action():
     # 在 ACTION_FILE 锁内读+删，且仅当解析出 action 时才删除：
     # 配合 LuCI 侧的原子写，避免撕裂/空读时把刚入队的动作连文件一起删掉。

--- a/root/usr/lib/smart_srun/version_info.py
+++ b/root/usr/lib/smart_srun/version_info.py
@@ -120,15 +120,6 @@ def get_display_version(status_text=None, package_name=None):
     return _makefile_version()
 
 
-def get_luci_badge_label(status_text=None):
-    package_name = detect_installed_package_name(status_text=status_text)
-    if package_name == "luci-app-smart-srun-bundle":
-        return "Bundle 版"
-    if package_name == "luci-app-smart-srun":
-        return "标准版"
-    return "CLI 版"
-
-
 def get_luci_display_text(status_text=None):
     package_name = detect_installed_package_name(status_text=status_text)
     if package_name == "luci-app-smart-srun-bundle":

--- a/root/usr/lib/smart_srun/wireless.py
+++ b/root/usr/lib/smart_srun/wireless.py
@@ -139,33 +139,7 @@ def get_active_sta_section(cfg=None, wireless_data=None):
 
 def get_runtime_sta_section(cfg=None, wireless_data=None):
     data = wireless_data if wireless_data is not None else parse_wireless_iface_data()
-    active = get_active_sta_section(cfg, data)
-    if active:
-        return active
-
-    known_ssids = []
-    hotspot_ssid = str((cfg or {}).get("hotspot_ssid", "")).strip()
-    campus_ssid = str((cfg or {}).get("campus_ssid", "")).strip()
-    if hotspot_ssid:
-        known_ssids.append(hotspot_ssid)
-    if campus_ssid:
-        known_ssids.append(campus_ssid)
-
-    for sec in get_enabled_sta_sections(data):
-        profile = get_sta_profile_from_section(sec, data)
-        if str(profile.get("ssid", "")).strip() in known_ssids:
-            return sec
-
-    for sec in get_sta_sections(data):
-        profile = get_sta_profile_from_section(sec, data)
-        if str(profile.get("ssid", "")).strip() in known_ssids:
-            return sec
-
-    enabled = get_enabled_sta_sections(data)
-    if enabled:
-        return enabled[0]
-    sections = get_sta_sections(data)
-    return sections[0] if sections else None
+    return get_active_sta_section(cfg, data)
 
 
 def detect_runtime_mode(cfg, wireless_data=None):
@@ -296,19 +270,6 @@ def band_label(band):
 def get_radio_for_section(section, wireless_data=None):
     data = wireless_data if wireless_data is not None else parse_wireless_iface_data()
     return str(data.get(str(section or ""), {}).get("device", "")).strip() or None
-
-
-def find_sta_on_radio(radio, wireless_data=None):
-    data = wireless_data if wireless_data is not None else parse_wireless_iface_data()
-    target = str(radio or "").strip()
-    for sec in sorted(data.keys()):
-        opts = data[sec]
-        if (
-            str(opts.get("mode", "")).strip().lower() == "sta"
-            and str(opts.get("device", "")).strip() == target
-        ):
-            return sec
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1329,10 +1290,6 @@ def switch_sta_profile(cfg, expect_hotspot, reselect_ap=True, ap_context=None):
         "已切换为%s配置但未获取到IPv4地址（%s %s）。如果热点在另一频段，请在 LuCI 中手动指定热点 radio。"
         % (target["label"], radio or "?", bl),
     )
-
-
-def switch_to_hotspot(cfg):
-    return switch_sta_profile(cfg, expect_hotspot=True)
 
 
 def switch_to_campus(cfg, reselect_ap=True, ap_context=None):

--- a/root/www/luci-static/resources/smart_srun.js
+++ b/root/www/luci-static/resources/smart_srun.js
@@ -40,7 +40,6 @@
     if (line.indexOf('[错误]') !== -1) return 'error';
     if (line.indexOf('[警告]') !== -1) return 'warn';
     if (line.indexOf('[调试]') !== -1) return 'debug';
-    if (line.indexOf('[信息]') !== -1) return 'info';
     return 'info';
   }
 
@@ -904,8 +903,8 @@
         resetSchoolDefaultsForm();
         return;
       }
-      var schoolDefaults = (preset && preset.defaults) ? preset.defaults : {};
-      var loginShape = (preset && preset.observed_login_shape) ? preset.observed_login_shape : {};
+      var schoolDefaults = preset.defaults || {};
+      var loginShape = preset.observed_login_shape || {};
       var fieldMap = {
         base_url: 'jm-base_url',
         ac_id: 'jm-ac_id',
@@ -935,9 +934,6 @@
       if (schoolDefaults.access_mode) {
         var modeSel = document.getElementById('jm-access_mode');
         if (modeSel) modeSel.value = String(schoolDefaults.access_mode);
-      } else {
-        var fallbackModeSel = document.getElementById('jm-access_mode');
-        if (fallbackModeSel && selectedPresetId === NO_PRESET_ID) fallbackModeSel.value = 'wifi';
       }
       if (schoolDefaults.wired_iface !== undefined && schoolDefaults.wired_iface !== null) {
         var ifaceInput = document.getElementById('jm-wired_iface');


### PR DESCRIPTION
Remove unused Python helpers, unreachable STA fallback loops, unused LuCI data and duplicate branches. Existing dynamic school hooks, action handling, AP policies and compatibility paths remain in use. Runtime code is reduced by 81 lines without changing preset files or reformatting unrelated code.

Credit @haohaoget's multi-WAN work in #31 and @shijia257's interface binding in #32 directly in README, and document commit attribution and short-lived PR branches. Both original PR histories remain intact; GitHub's email/account attribution is separate from PR authorship.

Validation: grokbot Linux full suite passed (425 tests and 211 subtests), with Ruff, JavaScript syntax and preset synchronization checks passing. Native OpenWrt VM verification passed: 89 related tests, 28 installed file hashes, Python/Lua imports, CLI/procd and real LuCI HTTP checks; the existing configuration hash was unchanged. No physical-router deployment or network operations are part of this change.
