### PR TITLE
fix: repair minimal OpenWrt runtime and preserve configuration backups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 doc/school-presets.json text eol=lf
 root/usr/lib/smart_srun/school_presets_fallback.json text eol=lf
+root/lib/upgrade/keep.d/smart-srun text eol=lf

--- a/.github/prerelease-template.md
+++ b/.github/prerelease-template.md
@@ -18,7 +18,7 @@ OpenWrt SDK 版本：`${OPENWRT_VERSION}`
 
 说明：
 - 本软件包为纯脚本（Lua/Python/Shell），与 CPU 架构无关，所有 OpenWrt 设备均可直接安装。
-- 请直接下载本页 Assets 中的 `luci-app-smart-srun-bundle_*.ipk`（opkg / OpenWrt 23.05 及更早）或 `luci-app-smart-srun-bundle-*.apk`（apk / OpenWrt 24.10+ / 25.12+）进行安装。
+- 请直接下载本页 Assets 中的 `luci-app-smart-srun-bundle_*.ipk`（opkg / 官方 OpenWrt 24.10 及更早）或 `luci-app-smart-srun-bundle-*.apk`（apk / 官方 OpenWrt 25.12 及更新）进行安装；第三方固件以实际包管理器为准。
 - 安装命令：
   - opkg：`opkg install ./luci-app-smart-srun-bundle_*.ipk`
   - apk：`apk add --allow-untrusted ./luci-app-smart-srun-bundle-*.apk`

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -18,7 +18,7 @@ OpenWrt SDK 版本：`${OPENWRT_VERSION}`
 
 说明：
 - 本软件包为纯脚本（Lua/Python/Shell），与 CPU 架构无关，所有 OpenWrt 设备均可直接安装。
-- 请直接下载本页 Assets 中的 `luci-app-smart-srun-bundle_*.ipk`（opkg / OpenWrt 23.05 及更早）或 `luci-app-smart-srun-bundle-*.apk`（apk / OpenWrt 24.10+ / 25.12+）进行安装。
+- 请直接下载本页 Assets 中的 `luci-app-smart-srun-bundle_*.ipk`（opkg / 官方 OpenWrt 24.10 及更早）或 `luci-app-smart-srun-bundle-*.apk`（apk / 官方 OpenWrt 25.12 及更新）进行安装；第三方固件以实际包管理器为准。
 - 安装命令：
   - opkg：`opkg install ./luci-app-smart-srun-bundle_*.ipk`
   - apk：`apk add --allow-untrusted ./luci-app-smart-srun-bundle-*.apk`

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -1,7 +1,7 @@
 name: pre-release build
 
-# Builds both .ipk (opkg, OpenWrt 23.05/older) and .apk (apk, OpenWrt 24.10+
-# / 25.12+) and publishes them as a single pre-release with two bundle assets
+# Builds both .ipk (opkg, OpenWrt 24.10/older) and .apk (apk, OpenWrt 25.12+)
+# and publishes them as a single pre-release with two bundle assets
 # and one combined split-packages zip.
 #
 # The two SDK builds run in parallel via matrix; the publish job waits for
@@ -19,7 +19,7 @@ on:
         required: false
         default: "23.05.5"
       openwrt_apk_version:
-        description: "OpenWrt release version for apk build (24.10.x / 25.12.x)"
+        description: "OpenWrt release version for apk build (25.12.x or newer)"
         required: false
         default: "25.12.2"
       version:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,7 +1,7 @@
 name: Version Release Build
 
-# Builds both .ipk (opkg, OpenWrt 23.05/older) and .apk (apk, OpenWrt 24.10+
-# / 25.12+) and publishes them as a single formal release with two bundle
+# Builds both .ipk (opkg, OpenWrt 24.10/older) and .apk (apk, OpenWrt 25.12+)
+# and publishes them as a single formal release with two bundle
 # assets and one combined split-packages zip.
 #
 # Mirrors build-prerelease.yml; the only differences are that `version` is
@@ -15,7 +15,7 @@ on:
         required: true
         default: "23.05.5"
       openwrt_apk_version:
-        description: "OpenWrt release version for apk build (24.10.x / 25.12.x)"
+        description: "OpenWrt release version for apk build (25.12.x or newer)"
         required: true
         default: "25.12.2"
       version:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,13 @@ root/
 
 ## 运行环境约束
 
-- 设备端只依赖 OpenWrt `python3-light`，shipped Python 必须保持标准库-only。
+- 设备端使用 OpenWrt `python3-light` 及 `Makefile` 声明的标准库拆分包（`python3-urllib`、`python3-codecs`、`python3-openssl`）；shipped Python 必须保持标准库-only。新增 import 时核对 OpenWrt 拆包，完整桌面 Python 会掩盖缺失依赖。
 - 模块使用裸 import，例如 `import orchestrator`、`from config import load_config`。`client.py` 和 `schools/__init__.py` 负责注入路径，不要改成 package-relative imports。
 - 持久化配置是 UCI 风格字符串，布尔值通常是 `"0"` / `"1"`，数字也以字符串保存。
 - LuCI 前端保持纯 ES5、手写 DOM 与 `XMLHttpRequest`，不引入 bundler、npm 运行时或前端依赖。
 - `school_extra` 是 runtime 私有命名空间；未知 key 会被归一化丢弃，不要偷偷塞顶层配置。
 - `Makefile` 的 `Build/Compile` 为空是正常的；真正构建由 OpenWrt SDK 完成。
+- 用户配置继续保存在 `/usr/lib/smart_srun/config.json`，由 `root/lib/upgrade/keep.d/smart-srun` 纳入保留配置刷机与系统备份；不要把随包默认值或运行态加入清单。
 - 保持既有文件的排版、字段顺序及紧凑或展开写法；业务改动不得附带批量格式化。
 - 内部计划和验收报告保存在本地 `.codex/`，不要提交到 `doc/`。
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-RUNTIME_DEPENDS:=+python3-light +python3-urllib
+# urllib needs unicodedata (codecs) for IDNA and _ssl (openssl) for HTTPS.
+RUNTIME_DEPENDS:=+python3-light +python3-urllib +python3-codecs +python3-openssl
 # Keep empty so SDK CI only packs our files (see 1.3.4). Declaring luci-base
 # / luci-compat forces a Lua LuCI stack the release SDK cannot build.
 LUCI_FILE_DEPENDS:=
@@ -33,6 +34,9 @@ endef
 define Package/smart-srun/install
 	$(INSTALL_DIR) $(1)/usr/lib/smart_srun
 	$(INSTALL_DIR) $(1)/usr/lib/smart_srun/schools
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DATA) $(CURDIR)/root/lib/upgrade/keep.d/smart-srun \
+		$(1)/lib/upgrade/keep.d/smart-srun
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) $(CURDIR)/root/usr/lib/smart_srun/*.py \
@@ -105,6 +109,9 @@ endef
 define Package/luci-app-smart-srun-bundle/install
 	$(INSTALL_DIR) $(1)/usr/lib/smart_srun
 	$(INSTALL_DIR) $(1)/usr/lib/smart_srun/schools
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DATA) $(CURDIR)/root/lib/upgrade/keep.d/smart-srun \
+		$(1)/lib/upgrade/keep.d/smart-srun
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) $(CURDIR)/root/usr/lib/smart_srun/*.py \

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@
 
 ## 安装包说明
 
-仓库构建产出三个 ipk 包：
+仓库为以下三个包分别构建 ipk / apk 格式：
 
 | 包名 | 说明 | 依赖 |
 |------|------|------|
-| `smart-srun` | 基础包：守护进程 + CLI | `python3-light` |
+| `smart-srun` | 基础包：守护进程 + CLI | `python3-light`、`python3-urllib`、`python3-codecs`、`python3-openssl` |
 | `luci-app-smart-srun` | 标准 LuCI Web 界面包（用于 opkg / LuCI 软件包管理升级） | `smart-srun`、LuCI 运行环境 |
-| `luci-app-smart-srun-bundle` | 自包含安装包：CLI + LuCI 一起打包，适合手动下载安装 | `python3-light`、LuCI 运行环境 |
+| `luci-app-smart-srun-bundle` | 自包含安装包：CLI + LuCI 一起打包，适合手动下载安装 | 与 `smart-srun` 相同的 Python 依赖、LuCI 运行环境 |
 
 - 最少安装步骤：直接安装 `luci-app-smart-srun-bundle`
 - 仅CLI：安装 `smart-srun` 即可
@@ -47,8 +47,9 @@
 **以下操作请在路由器连上互联网的情况进行！**
 
 1. 下载最新安装包：[Releases](https://github.com/matthewlu070111/smart-srun/releases)
-   - OpenWrt 23.05 及更早（opkg 系统）→ 下载 `*.ipk`
-   - OpenWrt 24.10+ / 25.12+（apk 系统）→ 下载 `*.apk`
+   - opkg 系统（官方 OpenWrt 24.10 及更早）→ 下载 `*.ipk`
+   - apk 系统（官方 OpenWrt 25.12 及更新）→ 下载 `*.apk`
+   - 第三方固件请以设备实际包管理器为准，参见 [OpenWrt 软件包管理说明](https://openwrt.org/docs/guide-user/additional-software/managing_packages)。
 2. 安装：
 #### 使用 LuCI 网页面板安装：
 1. 登录 LuCI 界面，进入 **系统**——**软件包** 页面。
@@ -69,7 +70,7 @@
 #### 使用命令行界面安装：
 1. 将安装包上传到 OpenWrt 设备，切换到该目录，执行：
 
-**opkg 系统（OpenWrt 23.05 及更早）：**
+**opkg 系统（官方 OpenWrt 24.10 及更早）：**
 ```sh
 # 仅 CLI
 opkg install smart-srun_*.ipk
@@ -82,7 +83,7 @@ opkg install luci-app-smart-srun_*.ipk
 opkg install luci-app-smart-srun-bundle_*.ipk
 ```
 
-**apk 系统（OpenWrt 24.10+ / 25.12+）：**
+**apk 系统（官方 OpenWrt 25.12 及更新）：**
 > 因为本项目是自签的第三方包，apk 默认会因 `UNTRUSTED signature` 拒绝安装，
 > 所以下面命令统一加 `--allow-untrusted`。这是 apk 的强制安全检查，
 ```sh
@@ -104,6 +105,34 @@ apk add --allow-untrusted ./luci-app-smart-srun-bundle-*.apk
 
 安装建议：
 - **不要把 `luci-app-smart-srun-bundle` 和标准 split 包混装**
+
+### 刷机时保留配置
+
+从 **1.5.1** 起，插件通过 OpenWrt 的 `/lib/upgrade/keep.d/smart-srun` 将
+`/usr/lib/smart_srun/config.json` 纳入系统备份和“保留配置”升级清单。校园网账号、
+热点密码和插件设置继续使用原来的 JSON 路径与格式，已有配置无需迁移。
+
+请在刷机前先升级插件至 1.5.1 或更新版本，保存配置，并确认以下命令能列出该文件：
+
+```sh
+sysupgrade -l | grep -Fx '/usr/lib/smart_srun/config.json'
+```
+
+随后在 LuCI 的 **系统 → 备份/升级** 中生成备份，或刷入固件时勾选 **保留配置**。
+新固件若未包含插件，仍需重新安装插件；安装后会继续读取恢复的配置。
+插件加入备份的内容仅为用户配置，不包含插件程序、随包默认值、学校预设缓存或运行状态。
+OpenWrt 的保留规则见 [sysupgrade 文档](https://openwrt.org/docs/techref/sysupgrade)。
+
+清空配置刷机（包括 `sysupgrade -n`）、恢复出厂设置或重新写入磁盘镜像不会自动保留文件。
+这种情况下，请事先把 `/usr/lib/smart_srun/config.json` 下载到电脑；重装插件后，
+将备份上传为 `/tmp/smart-srun-config.json`，再导入并重启服务：
+
+```sh
+srunnet config set -f /tmp/smart-srun-config.json
+/etc/init.d/smart_srun restart
+```
+
+备份包含账号和密码，请妥善保存；放在路由器 `/tmp` 中的副本会在重启时丢失。
 
 ## 使用
 ### LuCI 使用

--- a/root/lib/upgrade/keep.d/smart-srun
+++ b/root/lib/upgrade/keep.d/smart-srun
@@ -1,0 +1,2 @@
+# User-created accounts and settings; keep the existing JSON storage format.
+/usr/lib/smart_srun/config.json

--- a/root/usr/lib/smart_srun/updater.py
+++ b/root/usr/lib/smart_srun/updater.py
@@ -529,6 +529,24 @@ def _write_lock_pid(pid):
 def _acquire_lock():
     _ensure_parent(LOCK_FILE)
     try:
+        import fcntl
+    except ImportError:  # Non-POSIX development hosts.
+        return _claim_lock_pid()
+
+    # Keep this inode separate from the PID file: worker handoff replaces that
+    # file. Serialize initial PID publication and stale-lock recovery so a
+    # competitor cannot reclaim an empty/new lock and start a second install.
+    # Do not unlink the guard: waiters must always lock the same inode.
+    with open(LOCK_FILE + ".guard", "a", encoding="ascii") as guard:
+        try:
+            fcntl.flock(guard, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            raise RuntimeError("已有更新任务正在运行")
+        return _claim_lock_pid()
+
+
+def _claim_lock_pid():
+    try:
         fd = os.open(LOCK_FILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except OSError:
         # 锁文件已存在：若持有者进程已退出（崩溃 / 被服务重启杀掉）则视为陈旧锁，

--- a/scripts/hot_update.py
+++ b/scripts/hot_update.py
@@ -20,7 +20,9 @@ ROUTER_PASSWORD = os.environ.get("SMARTSRUN_ROUTER_PASSWORD")
 LUCI_BASE_URL = os.environ.get(
     "SMARTSRUN_LUCI_BASE_URL", "http://%s/cgi-bin/luci" % ROUTER_HOST
 )
-FORCE_LF_TARGETS = {"/etc/init.d/smart_srun", "/usr/bin/srunnet"}
+FORCE_LF_TARGETS = {
+    "/etc/init.d/smart_srun", "/usr/bin/srunnet", "/lib/upgrade/keep.d/smart-srun",
+}
 EXECUTABLE_TARGETS = ["/usr/bin/srunnet", "/etc/init.d/smart_srun"]
 PROBE_ROOT_PREFIX = "/tmp/smart_srun_probe"
 
@@ -120,6 +122,10 @@ RUNTIME_TARGETS = [
 ]
 
 LUA_AND_SERVICE_TARGETS = [
+    {
+        "local": "root/lib/upgrade/keep.d/smart-srun",
+        "remote": "/lib/upgrade/keep.d/smart-srun",
+    },
     {
         "local": "root/usr/lib/lua/luci/controller/smart_srun.lua",
         "remote": "/usr/lib/lua/luci/controller/smart_srun.lua",

--- a/tests/test_package_conflicts.py
+++ b/tests/test_package_conflicts.py
@@ -17,9 +17,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGES = ("smart-srun", "luci-app-smart-srun", "luci-app-smart-srun-bundle")
 BUILD_DEPENDS = {
-    "smart-srun": {"+python3-light", "+python3-urllib"},
+    "smart-srun": {"+python3-light", "+python3-urllib", "+python3-codecs", "+python3-openssl"},
     "luci-app-smart-srun": {"+smart-srun"},
-    "luci-app-smart-srun-bundle": {"+python3-light", "+python3-urllib"},
+    "luci-app-smart-srun-bundle": {"+python3-light", "+python3-urllib", "+python3-codecs", "+python3-openssl"},
 }
 CONFLICTS = {
     "smart-srun": set(),

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -1,0 +1,88 @@
+"""Exercise implicit HTTP dependencies absent from OpenWrt python3-light.
+
+The official packages feed separates unicodedata into python3-codecs and _ssl
+into python3-openssl on both release SDK branches (openwrt-23.05/25.12):
+lang/python/python3/files/python3-package-{codecs,openssl}.mk.
+Use a fresh interpreter so an earlier test cannot hide a missing module by
+preloading IDNA or HTTPS support into sys.modules.
+"""
+
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_ROOT = REPO_ROOT / "root" / "usr" / "lib" / "smart_srun"
+OPTIONAL_MODULES = {
+    "python3-codecs": "unicodedata",
+    "python3-openssl": "_ssl",
+    "python3-urllib": "urllib",
+}
+HTTP_SMOKE = r'''
+import sys
+
+blocked = set(sys.argv[2:])
+
+class OpenWrtModules:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in blocked:
+            raise ModuleNotFoundError("OpenWrt package missing: " + fullname)
+
+sys.meta_path.insert(0, OpenWrtModules())
+sys.path.insert(0, sys.argv[1])
+
+import cli
+import network
+import school_presets
+import updater
+
+assert network.HAVE_URLLIB, "Python HTTP client unavailable"
+assert "portal.example".encode("idna") == b"portal.example"
+assert updater._stdlib_http_is_usable(), "Updater HTTP client unavailable"
+assert school_presets.urlrequest is not None
+assert hasattr(network.http_client, "HTTPSConnection"), "HTTPS unavailable"
+import ssl
+context = ssl.create_default_context()
+assert context.check_hostname
+assert context.verify_mode == ssl.CERT_REQUIRED
+'''
+
+
+def smoke_runtime(packages):
+    blocked = [module for package, module in OPTIONAL_MODULES.items()
+               if package not in packages]
+    return subprocess.run(
+        [sys.executable, "-S", "-c", HTTP_SMOKE, str(MODULE_ROOT)] + blocked,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+class RuntimeDependencyTests(unittest.TestCase):
+    def test_declared_dependencies_supply_idna_and_verified_https(self):
+        makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        match = re.search(r"^RUNTIME_DEPENDS:=(.*)$", makefile, re.MULTILINE)
+        self.assertIsNotNone(match)
+        packages = {name.lstrip("+") for name in match.group(1).split()}
+        result = smoke_runtime(packages)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_smoke_exposes_missing_implicit_http_dependencies(self):
+        packages = set(OPTIONAL_MODULES)
+        for missing in ("python3-codecs", "python3-openssl"):
+            with self.subTest(package=missing):
+                result = smoke_runtime(packages - {missing})
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "unknown encoding: idna" if missing == "python3-codecs" else "HTTPS unavailable",
+                    result.stderr,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sysupgrade_backup.py
+++ b/tests/test_sysupgrade_backup.py
@@ -1,0 +1,103 @@
+"""Keep runtime-created user settings across OpenWrt keep-config upgrades."""
+
+import ast
+import importlib.util
+import io
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+KEEP_PATH = "/lib/upgrade/keep.d/smart-srun"
+CONFIG_PATH = "/usr/lib/smart_srun/config.json"
+
+
+def read_source(relative_path):
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+class SysupgradeBackupTests(unittest.TestCase):
+    def test_backup_covers_shared_user_config_without_programs_or_runtime_state(self):
+        entries = [
+            line.strip()
+            for line in read_source("root" + KEEP_PATH).splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual(entries, [CONFIG_PATH])
+
+        config_tree = ast.parse(read_source("root/usr/lib/smart_srun/config.py"))
+        config_path = next(
+            ast.literal_eval(node.value)
+            for node in config_tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "JSON_CONFIG_FILE"
+                for target in node.targets
+            )
+        )
+        self.assertEqual(config_path, CONFIG_PATH)
+        for relative_path in (
+            "root/usr/lib/lua/luci/controller/smart_srun.lua",
+            "root/usr/lib/lua/luci/model/cbi/smart_srun.lua",
+        ):
+            self.assertIn('local CONFIG_FILE = "%s"' % CONFIG_PATH,
+                          read_source(relative_path))
+        # The package must not ship a default config over restored credentials.
+        self.assertFalse((REPO_ROOT / ("root" + CONFIG_PATH)).exists())
+
+    def test_both_runtime_packages_install_the_backup_rule_as_data(self):
+        makefile = read_source("Makefile")
+        for package in ("smart-srun", "luci-app-smart-srun-bundle"):
+            with self.subTest(package=package):
+                install = re.search(
+                    r"^define Package/%s/install\n(.*?)^endef$" % package,
+                    makefile, re.MULTILINE | re.DOTALL,
+                )
+                self.assertIsNotNone(install)
+                body = " ".join(install.group(1).replace("\\\n", "").split())
+                self.assertIn("$(INSTALL_DIR) $(1)/lib/upgrade/keep.d", body)
+                self.assertIn(
+                    "$(INSTALL_DATA) $(CURDIR)/root%s $(1)%s"
+                    % (KEEP_PATH, KEEP_PATH), body,
+                )
+
+    def test_keep_rule_has_unix_line_endings_in_package_checkouts(self):
+        self.assertNotIn(b"\r", (REPO_ROOT / ("root" + KEEP_PATH)).read_bytes())
+        self.assertIn("root%s text eol=lf" % KEEP_PATH, read_source(".gitattributes"))
+
+    def test_hot_deploy_uploads_keep_rule_with_unix_paths_even_from_windows(self):
+        spec = importlib.util.spec_from_file_location(
+            "hot_update_backup_test", REPO_ROOT / "scripts/hot_update.py",
+        )
+        hot_update = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hot_update)
+        self.assertIn(
+            {"local": "root" + KEEP_PATH, "remote": KEEP_PATH},
+            hot_update.UPLOAD_TARGETS,
+        )
+        self.assertNotIn(KEEP_PATH, hot_update.EXECUTABLE_TARGETS)
+        target = next(
+            item for item in hot_update.remote_target_paths("/tmp/probe")
+            if item["original_remote"] == KEEP_PATH
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / target["local"]
+            source.parent.mkdir(parents=True)
+            source.write_bytes((CONFIG_PATH + "\r\n").encode("utf-8"))
+            output = io.BytesIO()
+            remote_file = mock.MagicMock()
+            remote_file.__enter__.return_value = output
+            sftp = mock.Mock()
+            sftp.file.return_value = remote_file
+            with mock.patch.object(hot_update, "REPO_ROOT", Path(temp_dir)):
+                hot_update.upload_files(sftp, [target])
+            sftp.file.assert_called_once_with("/tmp/probe" + KEEP_PATH, "wb")
+            self.assertEqual(output.getvalue(), (CONFIG_PATH + "\n").encode("utf-8"))
+            sftp.put.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -359,6 +359,75 @@ class InitScriptUpdateSafetyTests(unittest.TestCase):
 
 
 class LockWriteAtomicityTests(unittest.TestCase):
+    @unittest.skipUnless(os.name == "posix", "requires POSIX file locking")
+    def test_acquire_rejects_competitor_before_initial_pid_is_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_file = os.path.join(tmp, "update.lock")
+            original_open = os.open
+            attempted = []
+
+            def open_with_competitor(path, flags, *args, **kwargs):
+                fd = original_open(path, flags, *args, **kwargs)
+                if path == lock_file and not attempted:
+                    attempted.append(True)
+                    try:
+                        with self.assertRaisesRegex(RuntimeError, "已有更新任务"):
+                            updater._acquire_lock()
+                    except BaseException:
+                        os.close(fd)
+                        raise
+                return fd
+
+            with (
+                mock.patch.object(updater, "LOCK_FILE", lock_file),
+                mock.patch.object(updater, "_append_log"),
+                mock.patch.object(updater.os, "open", side_effect=open_with_competitor),
+            ):
+                updater._acquire_lock()
+                self.assertEqual(updater._read_lock_pid(), os.getpid())
+            self.assertEqual(attempted, [True])
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX file locking")
+    def test_acquire_rejects_competitor_during_stale_lock_recovery(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_file = os.path.join(tmp, "update.lock")
+            with open(lock_file, "w", encoding="ascii") as handle:
+                handle.write("12345")
+            original_remove = os.remove
+            attempted = []
+
+            def remove_with_competitor(path):
+                original_remove(path)
+                if path == lock_file and not attempted:
+                    attempted.append(True)
+                    with self.assertRaisesRegex(RuntimeError, "已有更新任务"):
+                        updater._acquire_lock()
+
+            with (
+                mock.patch.object(updater, "LOCK_FILE", lock_file),
+                mock.patch.object(updater, "_append_log"),
+                mock.patch.object(updater, "_pid_alive", return_value=False),
+                mock.patch.object(updater.os, "remove", side_effect=remove_with_competitor),
+            ):
+                updater._acquire_lock()
+                self.assertEqual(updater._read_lock_pid(), os.getpid())
+            self.assertEqual(attempted, [True])
+
+    def test_acquire_keeps_live_owner_and_recovers_dead_owner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_file = os.path.join(tmp, "update.lock")
+            with (
+                mock.patch.object(updater, "LOCK_FILE", lock_file),
+                mock.patch.object(updater, "_append_log"),
+            ):
+                updater._acquire_lock()
+                with mock.patch.object(updater, "_pid_alive", return_value=True):
+                    with self.assertRaisesRegex(RuntimeError, "已有更新任务"):
+                        updater._acquire_lock()
+                with mock.patch.object(updater, "_pid_alive", return_value=False):
+                    updater._acquire_lock()
+                self.assertEqual(updater._read_lock_pid(), os.getpid())
+
     def test_write_lock_pid_uses_atomic_replace(self):
         with tempfile.TemporaryDirectory() as tmp:
             lock_file = os.path.join(tmp, "update.lock")


### PR DESCRIPTION
修复 1.5.0 在最小 OpenWrt 环境中因 Python 拆包依赖缺失导致的域名解析与 HTTPS 失败，并让现有 JSON 配置随系统备份和保留配置刷机恢复。账号和配置继续使用原有路径与格式，无需迁移。

- CLI 与 bundle 共同声明 `python3-codecs`、`python3-openssl`，补齐 IDNA 和证书校验 HTTPS 所需模块。
- 添加精确的 `/lib/upgrade/keep.d/smart-srun` 规则，仅保留 `/usr/lib/smart_srun/config.json`；同步安装清单、热更新和使用说明。
- 审计发现升级 PID 锁发布与陈旧锁回收存在竞争窗口；用固定 guard 文件的短期 `flock` 防止并发安装，保留原有后台 worker 交接。
- 修正安装说明中 OpenWrt 24.10 的包格式：官方 24.10 及更早使用 opkg，25.12 起使用 apk；第三方固件以实际包管理器为准。

验证：Linux 全套 **442 passed、223 subtests passed，0 skipped**，GNU make、Lua 5.1 和 POSIX 竞态测试均实际执行；Ruff 0.16.5 与 Node 语法检查通过。Windows 全套 435 passed、7 平台跳过。两个 POSIX 升级锁回归在修改前稳定失败、修复后通过。官方 23.05.5 与 25.12.2 最小 rootfs 均已实际复现缺依赖，再验证安装依赖后的 IDNA/DNS、证书校验 HTTPS、运行模块导入和 CLI。授权真机的 `sysupgrade -l` 与真实备份归档均包含主 JSON，备份与原配置 SHA-256 一致，服务持续运行。

保留配置升级仍需使用 OpenWrt 的保留配置/备份恢复流程；清空配置刷机需提前导出，固件未包含插件时仍需重新安装插件。

Fixes #43
Fixes #42
